### PR TITLE
docs: clarify Image-to-Video UI in usage guide

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -75,10 +75,10 @@ If enhancement returns empty (e.g. safety filter), the app auto-retries with fil
 
 You can animate images into videos:
 
-1. Expand the **Image to Video** section
-2. Click **Select Image** to choose a source image
-3. Adjust **Image Strength** (1.0 = full influence, 0.0 = ignore image)
-4. The first frame will be conditioned on your image
+1. On the main **Generate** screen (prompt column), expand the **Image to Video** disclosure section — it sits below **Prompt Enhancement** and above **Negative Prompt**.
+2. Click **Select Source Image...** and pick an image file; it becomes the conditioned first frame.
+3. Optionally adjust **Image Strength** (1.0 = full influence, lower = more motion freedom).
+4. Write a prompt that describes the motion; then generate as usual.
 
 ## Adding Audio
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Aligns `docs/usage.md` Image-to-Video steps with the macOS app: correct disclosure location (Generate / prompt column), actual button copy (**Select Source Image...**), and brief flow for strength + prompt.

## Context

GitHub #39 — users could not spot image-to-video because the section is a collapsed disclosure. No runtime code changes.

## Related

Closes documentation gap for #39 (issue already closed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d97d7f05-700e-4ef8-a93a-d838cfe7c642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d97d7f05-700e-4ef8-a93a-d838cfe7c642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

