### PR TITLE
Add configurable Gemma text encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to LTX Video Generator will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.59] - 2026-05-07
+
+### Added
+- **Issue #54 — Configurable Gemma text encoder** — Add a Preferences picker for the generation text encoder with bf16 and 4-bit Gemma options. The selected encoder is captured per generation and passed to `mlx_video.generate_av` via `--text-encoder-repo`, allowing lower-memory Macs to use `mlx-community/gemma-3-12b-it-4bit`.
+
 ## [2.3.58] - 2026-05-02
 
 ### Fixed

--- a/LTXVideoGenerator/LTXVideoGenerator.xcodeproj/project.pbxproj
+++ b/LTXVideoGenerator/LTXVideoGenerator.xcodeproj/project.pbxproj
@@ -381,7 +381,7 @@
 				CODE_SIGN_ENTITLEMENTS = LTXVideoGenerator.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -392,7 +392,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.3.58;
+				MARKETING_VERSION = 2.3.59;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ltxvideo.generator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -409,7 +409,7 @@
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 529AKJCKRC;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -420,7 +420,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.3.58;
+				MARKETING_VERSION = 2.3.59;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jamescampbell.ltxvideogenerator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LTXVideoGenerator/Resources/av_generator.py
+++ b/LTXVideoGenerator/Resources/av_generator.py
@@ -108,6 +108,12 @@ def main():
         help="Model repository ID (selected in app preferences)",
     )
     parser.add_argument(
+        "--text-encoder-repo",
+        type=str,
+        default="mlx-community/gemma-3-12b-it-bf16",
+        help="Gemma text encoder repository ID (selected in app preferences)",
+    )
+    parser.add_argument(
         "--image",
         "-i",
         type=str,
@@ -159,7 +165,7 @@ def main():
 
         generate_video_with_audio(
             model_repo=args.model_repo,
-            text_encoder_repo=None,
+            text_encoder_repo=args.text_encoder_repo,
             prompt=args.prompt,
             height=args.height,
             width=args.width,

--- a/LTXVideoGenerator/Sources/Models/GenerationRequest.swift
+++ b/LTXVideoGenerator/Sources/Models/GenerationRequest.swift
@@ -17,6 +17,15 @@ struct LTXModel: Identifiable, Codable, Hashable {
     }
 }
 
+struct LTXTextEncoder: Identifiable, Codable, Hashable {
+    let id: String
+    let repo: String
+    let displayName: String
+    let downloadSize: String
+    let qualityWarning: String?
+    let tips: String?
+}
+
 enum LTXModelCatalog {
     static let selectedModelIDKey = "selectedModelID"
     // Keep default on Unified unless the user explicitly changes it.
@@ -81,6 +90,53 @@ enum LTXModelCatalog {
     }
 }
 
+enum LTXTextEncoderCatalog {
+    static let selectedTextEncoderIDKey = "selectedTextEncoderID"
+    // Match upstream mlx-video-with-audio default unless the user explicitly opts into Q4.
+    static let defaultTextEncoderID = "gemma3_12b_bf16"
+
+    static let all: [LTXTextEncoder] = [
+        LTXTextEncoder(
+            id: "gemma3_12b_bf16",
+            repo: "mlx-community/gemma-3-12b-it-bf16",
+            displayName: "Gemma 3 12B bf16",
+            downloadSize: "~24GB",
+            qualityWarning: nil,
+            tips: "Quality-first upstream default. Uses substantially more memory during text encoding."
+        ),
+        LTXTextEncoder(
+            id: "gemma3_12b_4bit",
+            repo: "mlx-community/gemma-3-12b-it-4bit",
+            displayName: "Gemma 3 12B 4-bit",
+            downloadSize: "~7GB",
+            qualityWarning: "Quantized: much lower memory use with possible prompt-conditioning quality tradeoffs.",
+            tips: "Recommended for 16GB/32GB Macs or quantized video models."
+        ),
+    ]
+
+    static var defaultTextEncoder: LTXTextEncoder {
+        all.first { $0.id == defaultTextEncoderID } ?? all[0]
+    }
+
+    static func textEncoder(id: String) -> LTXTextEncoder? {
+        all.first { $0.id == id }
+    }
+
+    static func textEncoder(repo: String) -> LTXTextEncoder? {
+        all.first { $0.repo == repo }
+    }
+
+    static func resolvedTextEncoder(id: String?) -> LTXTextEncoder {
+        guard let id, let textEncoder = textEncoder(id: id) else { return defaultTextEncoder }
+        return textEncoder
+    }
+
+    static func selectedTextEncoder(userDefaults: UserDefaults = .standard) -> LTXTextEncoder {
+        let id = userDefaults.string(forKey: selectedTextEncoderIDKey) ?? defaultTextEncoderID
+        return resolvedTextEncoder(id: id)
+    }
+}
+
 struct GenerationRequest: Identifiable, Codable, Equatable {
     let id: UUID
     let prompt: String
@@ -95,6 +151,7 @@ struct GenerationRequest: Identifiable, Codable, Equatable {
     let gemmaRepetitionPenalty: Double  // Gemma prompt enhancement repetition penalty
     let gemmaTopP: Double              // Gemma prompt enhancement top-p sampling
     let modelId: String                // Selected model ID from catalog
+    let textEncoderId: String          // Selected Gemma text encoder ID from catalog
     var parameters: GenerationParameters
     let createdAt: Date
     var status: GenerationStatus
@@ -128,6 +185,7 @@ struct GenerationRequest: Identifiable, Codable, Equatable {
         gemmaRepetitionPenalty: Double = 1.2,
         gemmaTopP: Double = 0.9,
         modelId: String = LTXModelCatalog.defaultModelID,
+        textEncoderId: String = LTXTextEncoderCatalog.defaultTextEncoderID,
         parameters: GenerationParameters = .default,
         createdAt: Date = Date(),
         status: GenerationStatus = .pending
@@ -145,6 +203,7 @@ struct GenerationRequest: Identifiable, Codable, Equatable {
         self.gemmaRepetitionPenalty = gemmaRepetitionPenalty
         self.gemmaTopP = gemmaTopP
         self.modelId = modelId
+        self.textEncoderId = textEncoderId
         self.parameters = parameters
         self.createdAt = createdAt
         self.status = status
@@ -164,6 +223,7 @@ struct GenerationRequest: Identifiable, Codable, Equatable {
         case gemmaRepetitionPenalty
         case gemmaTopP
         case modelId
+        case textEncoderId
         case parameters
         case createdAt
         case status
@@ -184,6 +244,7 @@ struct GenerationRequest: Identifiable, Codable, Equatable {
         gemmaRepetitionPenalty = try container.decode(Double.self, forKey: .gemmaRepetitionPenalty)
         gemmaTopP = try container.decode(Double.self, forKey: .gemmaTopP)
         modelId = try container.decodeIfPresent(String.self, forKey: .modelId) ?? LTXModelCatalog.defaultModelID
+        textEncoderId = try container.decodeIfPresent(String.self, forKey: .textEncoderId) ?? LTXTextEncoderCatalog.defaultTextEncoderID
         parameters = try container.decode(GenerationParameters.self, forKey: .parameters)
         createdAt = try container.decode(Date.self, forKey: .createdAt)
         status = try container.decode(GenerationStatus.self, forKey: .status)

--- a/LTXVideoGenerator/Sources/Services/APIServer.swift
+++ b/LTXVideoGenerator/Sources/Services/APIServer.swift
@@ -122,7 +122,7 @@ class APIServer: ObservableObject {
                 "endpoints": [
                     "GET /status": "Server and generation status",
                     "GET /queue": "Current generation queue",
-                    "POST /generate": "Submit generation request (optional model_id)",
+                    "POST /generate": "Submit generation request (optional model_id, text_encoder_id)",
                     "DELETE /queue/:id": "Cancel a queued request"
                 ]
             ])
@@ -139,6 +139,7 @@ class APIServer: ObservableObject {
         case ("GET", "/queue"):
             let queue = generationService.queue.map { request -> [String: Any] in
                 let model = LTXModelCatalog.resolvedModel(id: request.modelId)
+                let textEncoder = LTXTextEncoderCatalog.resolvedTextEncoder(id: request.textEncoderId)
                 return [
                     "id": request.id.uuidString,
                     "prompt": request.prompt,
@@ -148,6 +149,11 @@ class APIServer: ObservableObject {
                         "id": model.id,
                         "repo": model.repo,
                         "display_name": model.displayName,
+                    ],
+                    "text_encoder": [
+                        "id": textEncoder.id,
+                        "repo": textEncoder.repo,
+                        "display_name": textEncoder.displayName,
                     ],
                     "parameters": [
                         "width": request.parameters.width,
@@ -176,6 +182,8 @@ class APIServer: ObservableObject {
             let musicGenre = body["music_genre"] as? String
             let requestedModelID = body["model_id"] as? String
             let requestedModelRepo = body["model_repo"] as? String
+            let requestedTextEncoderID = body["text_encoder_id"] as? String
+            let requestedTextEncoderRepo = body["text_encoder_repo"] as? String
             let resolvedModel: LTXModel
             if let requestedModelID, let byID = LTXModelCatalog.model(id: requestedModelID) {
                 resolvedModel = byID
@@ -183,6 +191,14 @@ class APIServer: ObservableObject {
                 resolvedModel = byRepo
             } else {
                 resolvedModel = LTXModelCatalog.selectedModel()
+            }
+            let resolvedTextEncoder: LTXTextEncoder
+            if let requestedTextEncoderID, let byID = LTXTextEncoderCatalog.textEncoder(id: requestedTextEncoderID) {
+                resolvedTextEncoder = byID
+            } else if let requestedTextEncoderRepo, let byRepo = LTXTextEncoderCatalog.textEncoder(repo: requestedTextEncoderRepo) {
+                resolvedTextEncoder = byRepo
+            } else {
+                resolvedTextEncoder = LTXTextEncoderCatalog.selectedTextEncoder()
             }
             
             var params = GenerationParameters.default
@@ -205,6 +221,7 @@ class APIServer: ObservableObject {
                 musicEnabled: musicEnabled,
                 musicGenre: musicGenre,
                 modelId: resolvedModel.id,
+                textEncoderId: resolvedTextEncoder.id,
                 parameters: params
             )
             
@@ -214,6 +231,8 @@ class APIServer: ObservableObject {
                 "status": "queued",
                 "model_id": request.modelId,
                 "model_repo": resolvedModel.repo,
+                "text_encoder_id": request.textEncoderId,
+                "text_encoder_repo": resolvedTextEncoder.repo,
                 "message": "Generation request added to queue"
             ])
             

--- a/LTXVideoGenerator/Sources/Services/LTXBridge.swift
+++ b/LTXVideoGenerator/Sources/Services/LTXBridge.swift
@@ -127,6 +127,8 @@ class LTXBridge {
         
         let selectedModel = LTXModelCatalog.resolvedModel(id: request.modelId)
         let modelRepo = selectedModel.repo
+        let selectedTextEncoder = LTXTextEncoderCatalog.resolvedTextEncoder(id: request.textEncoderId)
+        let textEncoderRepo = selectedTextEncoder.repo
         let oomRecoveryHint = "Metal ran out of memory during generation. Retry with safer settings: 512x320 resolution, 25/33/49 frames, 24 FPS, and tiling set to aggressive. Close memory-heavy apps, then retry."
         let isImageToVideo = request.isImageToVideo
         let modeDescription = isImageToVideo ? "image-to-video" : "text-to-video"
@@ -216,7 +218,9 @@ try:
     log(f"MLX device: Apple Silicon")
     
     model_repo = "\(modelRepo)"
+    text_encoder_repo = "\(textEncoderRepo)"
     log(f"Model: {model_repo}")
+    log(f"Text encoder: {text_encoder_repo}")
     local_mlx_video_repo = os.path.expanduser("~/projects/mlx-video-with-audio")
     local_has_mlx = os.path.exists(os.path.join(local_mlx_video_repo, "mlx_video", "generate_av.py"))
 
@@ -301,6 +305,7 @@ try:
         "--cfg-scale", str(\(params.guidanceScale)),
         "--output-path", "\(outputPath)",
         "--model-repo", model_repo,
+        "--text-encoder-repo", text_encoder_repo,
         "--tiling", "\(params.vaeTilingMode)",
     ]
     if negative_prompt.strip():

--- a/LTXVideoGenerator/Sources/Views/HistoryView.swift
+++ b/LTXVideoGenerator/Sources/Views/HistoryView.swift
@@ -225,6 +225,7 @@ struct HistoryView: View {
             musicEnabled: result.hasMusic,
             musicGenre: result.musicGenre,
             modelId: result.modelId,
+            textEncoderId: LTXTextEncoderCatalog.selectedTextEncoder().id,
             parameters: params
         )
         generationService.addToQueue(request)

--- a/LTXVideoGenerator/Sources/Views/PreferencesView.swift
+++ b/LTXVideoGenerator/Sources/Views/PreferencesView.swift
@@ -12,6 +12,7 @@ struct PreferencesView: View {
     /// When true, always prepend ~/projects/mlx-video-with-audio to PYTHONPATH if present (dev override).
     @AppStorage("useLocalMlxVideoRepo") private var useLocalMlxVideoRepo = false
     @AppStorage(LTXModelCatalog.selectedModelIDKey) private var selectedModelID = LTXModelCatalog.defaultModelID
+    @AppStorage(LTXTextEncoderCatalog.selectedTextEncoderIDKey) private var selectedTextEncoderID = LTXTextEncoderCatalog.defaultTextEncoderID
 
     @State private var pythonStatus: (success: Bool, message: String)?
     @State private var pythonDetails: PythonDetails?
@@ -26,6 +27,10 @@ struct PreferencesView: View {
 
     private var selectedModel: LTXModel {
         LTXModelCatalog.resolvedModel(id: selectedModelID)
+    }
+
+    private var selectedTextEncoder: LTXTextEncoder {
+        LTXTextEncoderCatalog.resolvedTextEncoder(id: selectedTextEncoderID)
     }
 
     private var appVersionText: String {
@@ -241,6 +246,41 @@ struct PreferencesView: View {
                     .padding(.vertical, 4)
 
                     if let qualityWarning = selectedModel.qualityWarning {
+                        HStack(alignment: .top, spacing: 8) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundStyle(.orange)
+                            Text(qualityWarning)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    Picker("Text Encoder", selection: $selectedTextEncoderID) {
+                        ForEach(LTXTextEncoderCatalog.all) { textEncoder in
+                            Text("\(textEncoder.displayName) (\(textEncoder.downloadSize))").tag(textEncoder.id)
+                        }
+                    }
+                    .pickerStyle(.menu)
+
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: "textformat.abc")
+                            .foregroundStyle(.blue)
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(selectedTextEncoder.displayName)
+                                .font(.caption.bold())
+                            Text("Uses \(selectedTextEncoder.repo) for generation prompt encoding.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            if let tips = selectedTextEncoder.tips {
+                                Text(tips)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .padding(.vertical, 4)
+
+                    if let qualityWarning = selectedTextEncoder.qualityWarning {
                         HStack(alignment: .top, spacing: 8) {
                             Image(systemName: "exclamationmark.triangle.fill")
                                 .foregroundStyle(.orange)

--- a/LTXVideoGenerator/Sources/Views/PromptInputView.swift
+++ b/LTXVideoGenerator/Sources/Views/PromptInputView.swift
@@ -24,6 +24,7 @@ struct PromptInputView: View {
     @AppStorage("elevenLabsApiKey") private var elevenLabsApiKey = ""
     @AppStorage("enableGemmaPromptEnhancement") private var enableGemmaPromptEnhancement = false
     @AppStorage(LTXModelCatalog.selectedModelIDKey) private var selectedModelID = LTXModelCatalog.defaultModelID
+    @AppStorage(LTXTextEncoderCatalog.selectedTextEncoderIDKey) private var selectedTextEncoderID = LTXTextEncoderCatalog.defaultTextEncoderID
     @State private var voiceoverSource: AudioSource = .mlxAudio
     @State private var selectedElevenLabsVoice: String = "21m00Tcm4TlvDq8ikWAM"
     @State private var selectedMLXVoice: String = "af_heart"
@@ -714,6 +715,7 @@ struct PromptInputView: View {
             gemmaRepetitionPenalty: gemmaRepetitionPenalty,
             gemmaTopP: gemmaTopP,
             modelId: selectedModelID,
+            textEncoderId: selectedTextEncoderID,
             parameters: parameters
         )
         generationService.addToQueue(request)
@@ -793,6 +795,7 @@ struct PromptInputView: View {
                 gemmaRepetitionPenalty: gemmaRepetitionPenalty,
                 gemmaTopP: gemmaTopP,
                 modelId: selectedModelID,
+                textEncoderId: selectedTextEncoderID,
                 parameters: GenerationParameters(
                     numInferenceSteps: parameters.numInferenceSteps,
                     guidanceScale: parameters.guidanceScale,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a Gemma text encoder catalog with bf16 and 4-bit options.
- Add a Preferences model picker for the text encoder alongside the video model.
- Capture the selected text encoder per generation and pass it to `mlx_video.generate_av` via `--text-encoder-repo`.
- Expose text encoder selection in the local API request/queue payloads.
- Prepare release metadata for `v2.3.59`.

## Testing
- `python3 -m black LTXVideoGenerator/Resources/av_generator.py`
- `python3 -m py_compile LTXVideoGenerator/Resources/av_generator.py`
- `git diff --check`
- `swift build` could not run in this Linux cloud image because `swift` is not installed.

Fixes #54.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f23e08eb-2661-491a-9e43-2ebbc40a181d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f23e08eb-2661-491a-9e43-2ebbc40a181d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

