### PR TITLE
v2.3.60: fix generation runtime issues (#53, #48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Fixed
-- **Issue #53 — SIGKILL / jetsam during text encoder** — Detect subprocess SIGKILL (exit code -9) and surface an actionable message (smaller Gemma text encoder in Preferences, aggressive VAE tiling, lower resolution/frames, close other apps) with approximate free RAM and model/encoder ids. Append the same summary and a stderr-focused log excerpt to `/tmp/ltx_generation.log`.
-- **Issue #48 — Metal “Impacting Interactivity” with aggressive tiling** — Detect `kIOGPUCommandBufferCallbackErrorImpactingInteractivity` / code -6 patterns and explain the Metal watchdog + tiling tradeoff. After a failure with **Aggressive** VAE tiling, the next run automatically uses **Auto** once (persisted hint via `UserDefaults`) until a generation succeeds.
-
 ### Added
 - **Memory preflight** — Non-dismissable-by-default banner when a large unified bf16 model is paired with Gemma 12B bf16 on Macs with under 32 GB physical memory (rough unified-memory guidance using `host_statistics64`).
 - **Text encoder presets** — Gemma 4B bf16 (`mlx-community/gemma-3-4b-it-bf16`) and a **Custom Hugging Face repo** field in Preferences (alongside clearer labels for 12B bf16 and 12B 4-bit).
+
+## [2.3.60] - 2026-05-06
+
+### Fixed
+- **Issue #53 — SIGKILL / jetsam during text encoder** — Detect subprocess SIGKILL (exit code -9) and surface an actionable message (smaller Gemma text encoder in Preferences, aggressive VAE tiling, lower resolution/frames, close other apps) with approximate free RAM and model/encoder ids. Append the same summary and a stderr-focused log excerpt to `/tmp/ltx_generation.log`.
+- **Issue #48 — Metal “Impacting Interactivity” with aggressive tiling** — Detect `kIOGPUCommandBufferCallbackErrorImpactingInteractivity` / code -6 patterns and explain the Metal watchdog + tiling tradeoff. After a failure with **Aggressive** VAE tiling, the next run automatically uses **Auto** once (persisted hint via `UserDefaults`) until a generation succeeds.
 
 ## [2.3.59] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to LTX Video Generator will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- **Issue #53 — SIGKILL / jetsam during text encoder** — Detect subprocess SIGKILL (exit code -9) and surface an actionable message (smaller Gemma text encoder in Preferences, aggressive VAE tiling, lower resolution/frames, close other apps) with approximate free RAM and model/encoder ids. Append the same summary and a stderr-focused log excerpt to `/tmp/ltx_generation.log`.
+- **Issue #48 — Metal “Impacting Interactivity” with aggressive tiling** — Detect `kIOGPUCommandBufferCallbackErrorImpactingInteractivity` / code -6 patterns and explain the Metal watchdog + tiling tradeoff. After a failure with **Aggressive** VAE tiling, the next run automatically uses **Auto** once (persisted hint via `UserDefaults`) until a generation succeeds.
+
+### Added
+- **Memory preflight** — Non-dismissable-by-default banner when a large unified bf16 model is paired with Gemma 12B bf16 on Macs with under 32 GB physical memory (rough unified-memory guidance using `host_statistics64`).
+- **Text encoder presets** — Gemma 4B bf16 (`mlx-community/gemma-3-4b-it-bf16`) and a **Custom Hugging Face repo** field in Preferences (alongside clearer labels for 12B bf16 and 12B 4-bit).
+
 ## [2.3.59] - 2026-05-07
 
 ### Added

--- a/LTXVideoGenerator/LTXVideoGenerator.xcodeproj/project.pbxproj
+++ b/LTXVideoGenerator/LTXVideoGenerator.xcodeproj/project.pbxproj
@@ -404,7 +404,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.3.59;
+				MARKETING_VERSION = 2.3.60;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ltxvideo.generator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -432,7 +432,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.3.59;
+				MARKETING_VERSION = 2.3.60;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jamescampbell.ltxvideogenerator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LTXVideoGenerator/LTXVideoGenerator.xcodeproj/project.pbxproj
+++ b/LTXVideoGenerator/LTXVideoGenerator.xcodeproj/project.pbxproj
@@ -32,6 +32,9 @@
 		AA00002B /* AudioService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00002C; };
 		AA00002D /* AddAudioView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00002E; };
 		AA000035 /* CharacterProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000036; };
+		AA000190 /* MacOSSystemMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000191; };
+		AA000192 /* LTXGenerationLogSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000193; };
+		AA000194 /* GenerationFailureRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000195; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -59,6 +62,9 @@
 		AA00002C /* AudioService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioService.swift; sourceTree = "<group>"; };
 		AA00002E /* AddAudioView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAudioView.swift; sourceTree = "<group>"; };
 		AA000036 /* CharacterProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterProfile.swift; sourceTree = "<group>"; };
+		AA000191 /* MacOSSystemMemory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacOSSystemMemory.swift; sourceTree = "<group>"; };
+		AA000193 /* LTXGenerationLogSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LTXGenerationLogSummary.swift; sourceTree = "<group>"; };
+		AA000195 /* GenerationFailureRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationFailureRecovery.swift; sourceTree = "<group>"; };
 		AA000030 /* LTXVideoGenerator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LTXVideoGenerator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -130,6 +136,9 @@
 			isa = PBXGroup;
 			children = (
 				AA00000E /* LTXBridge.swift */,
+				AA000191 /* MacOSSystemMemory.swift */,
+				AA000193 /* LTXGenerationLogSummary.swift */,
+				AA000195 /* GenerationFailureRecovery.swift */,
 				AA000010 /* GenerationService.swift */,
 				AA000012 /* HistoryManager.swift */,
 				AA000014 /* PresetManager.swift */,
@@ -240,6 +249,9 @@
 				AA00000B /* Preset.swift in Sources */,
 				AA000035 /* CharacterProfile.swift in Sources */,
 				AA00000D /* LTXBridge.swift in Sources */,
+				AA000190 /* MacOSSystemMemory.swift in Sources */,
+				AA000192 /* LTXGenerationLogSummary.swift in Sources */,
+				AA000194 /* GenerationFailureRecovery.swift in Sources */,
 				AA00000F /* GenerationService.swift in Sources */,
 				AA000011 /* HistoryManager.swift in Sources */,
 				AA000013 /* PresetManager.swift in Sources */,

--- a/LTXVideoGenerator/Sources/Models/GenerationRequest.swift
+++ b/LTXVideoGenerator/Sources/Models/GenerationRequest.swift
@@ -92,6 +92,8 @@ enum LTXModelCatalog {
 
 enum LTXTextEncoderCatalog {
     static let selectedTextEncoderIDKey = "selectedTextEncoderID"
+    /// When the "Custom" preset is selected, this repo id is passed as `--text-encoder-repo`.
+    static let customTextEncoderRepoKey = "customTextEncoderRepo"
     // Match upstream mlx-video-with-audio default unless the user explicitly opts into Q4.
     static let defaultTextEncoderID = "gemma3_12b_bf16"
 
@@ -99,18 +101,34 @@ enum LTXTextEncoderCatalog {
         LTXTextEncoder(
             id: "gemma3_12b_bf16",
             repo: "mlx-community/gemma-3-12b-it-bf16",
-            displayName: "Gemma 3 12B bf16",
+            displayName: "Gemma 12B bf16 (max quality, ~24 GB RAM)",
             downloadSize: "~24GB",
             qualityWarning: nil,
             tips: "Quality-first upstream default. Uses substantially more memory during text encoding."
         ),
         LTXTextEncoder(
+            id: "gemma3_4b_bf16",
+            repo: "mlx-community/gemma-3-4b-it-bf16",
+            displayName: "Gemma 4B bf16 (balanced, ~10 GB RAM)",
+            downloadSize: "~10GB",
+            qualityWarning: nil,
+            tips: "Lower memory than 12B bf16; good balance for unified LTX models on 32 GB Macs."
+        ),
+        LTXTextEncoder(
             id: "gemma3_12b_4bit",
             repo: "mlx-community/gemma-3-12b-it-4bit",
-            displayName: "Gemma 3 12B 4-bit",
+            displayName: "Gemma 12B 4-bit (lowest RAM among presets, ~7 GB)",
             downloadSize: "~7GB",
             qualityWarning: "Quantized: much lower memory use with possible prompt-conditioning quality tradeoffs.",
-            tips: "Recommended for 16GB/32GB Macs or quantized video models."
+            tips: "Recommended for 16 GB Macs or when the 12B bf16 text encoder is killed by the system (SIGKILL)."
+        ),
+        LTXTextEncoder(
+            id: "custom",
+            repo: "",
+            displayName: "Custom Hugging Face repo…",
+            downloadSize: "varies",
+            qualityWarning: nil,
+            tips: "Enter any compatible Gemma MLX repo id below. Nothing is downloaded until you run a generation."
         ),
     ]
 
@@ -127,7 +145,22 @@ enum LTXTextEncoderCatalog {
     }
 
     static func resolvedTextEncoder(id: String?) -> LTXTextEncoder {
-        guard let id, let textEncoder = textEncoder(id: id) else { return defaultTextEncoder }
+        guard let id else { return defaultTextEncoder }
+        if id == "custom" {
+            let raw = UserDefaults.standard.string(forKey: customTextEncoderRepoKey)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return LTXTextEncoder(
+                id: "custom",
+                repo: raw,
+                displayName: raw.isEmpty ? "Custom (not set)" : "Custom (\(raw))",
+                downloadSize: "varies",
+                qualityWarning: raw.isEmpty
+                    ? "Set a repository id in Preferences → General (Custom text encoder field)."
+                    : nil,
+                tips: nil
+            )
+        }
+        guard let textEncoder = textEncoder(id: id) else { return defaultTextEncoder }
         return textEncoder
     }
 

--- a/LTXVideoGenerator/Sources/Services/GenerationFailureRecovery.swift
+++ b/LTXVideoGenerator/Sources/Services/GenerationFailureRecovery.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Persists a one-shot VAE tiling fallback after Metal watchdog failures with aggressive tiling (#48).
+enum GenerationFailureRecovery {
+    private static let pendingAggressiveToAutoKey = "ltxPendingTilingAggressiveToAutoFallback"
+
+    static var pendingAggressiveTilingToAutoFallback: Bool {
+        get { UserDefaults.standard.bool(forKey: pendingAggressiveToAutoKey) }
+        set { UserDefaults.standard.set(newValue, forKey: pendingAggressiveToAutoKey) }
+    }
+
+    static func recordMetalInteractivityFailureWithAggressiveTiling() {
+        pendingAggressiveTilingToAutoFallback = true
+    }
+
+    static func clearAfterSuccessfulGeneration() {
+        pendingAggressiveTilingToAutoFallback = false
+    }
+
+    static func effectiveTilingMode(requested: String) -> (mode: String, appliedFallback: Bool) {
+        if pendingAggressiveTilingToAutoFallback && requested == "aggressive" {
+            return ("auto", true)
+        }
+        return (requested, false)
+    }
+}

--- a/LTXVideoGenerator/Sources/Services/GenerationService.swift
+++ b/LTXVideoGenerator/Sources/Services/GenerationService.swift
@@ -187,6 +187,8 @@ class GenerationService: ObservableObject {
                     self?.statusMessage = message
                 }
             }
+
+            GenerationFailureRecovery.clearAfterSuccessfulGeneration()
             
             // Create result
             let completedAt = Date()

--- a/LTXVideoGenerator/Sources/Services/LTXBridge.swift
+++ b/LTXVideoGenerator/Sources/Services/LTXBridge.swift
@@ -26,6 +26,55 @@ enum LTXError: LocalizedError, Equatable {
 // Use subprocess to run MLX-based generation
 class LTXBridge {
     static let shared = LTXBridge()
+
+    private static let metalInteractivityUserHint =
+        "GPU command buffer was killed by the system because a single Metal kernel ran too long (typical with VAE tiling set to Aggressive on small resolutions or older hardware). Try tiling Auto or Conservative, lower resolution, or fewer frames. Disabling Aggressive tiling is the first thing to try.\n\n"
+        + "Update mlx-video-with-audio if you are on an older build. Full log: /tmp/ltx_generation.log"
+
+    private static func jetsamSigKillUserHint(modelRepo: String, textEncoderRepo: String) -> String {
+        let phys = MacOSSystemMemory.physicalMemoryGBFormatted()
+        let avail = MacOSSystemMemory.approximateAvailableMemoryGBFormatted()
+        return "macOS killed the generator process due to memory pressure. Try a smaller text encoder (for example mlx-community/gemma-3-4b-it-bf16 or a 4-bit quant), enable aggressive VAE tiling, lower resolution or frame count, or close other apps.\n\n"
+            + "Model: \(modelRepo). Text encoder: \(textEncoderRepo). This Mac reports about \(phys) GB physical memory and roughly \(avail) GB available (approximate).\n\n"
+            + "Open Preferences → General and use the Text Encoder picker (Gemma 4B bf16 or 4-bit). Full log: /tmp/ltx_generation.log"
+    }
+
+    private static func stderrIndicatesMetalInteractivity(_ stderr: String) -> Bool {
+        let low = stderr.lowercased()
+        return low.contains("diagnostic_metal_interactivity")
+            || low.contains("impacting interactivity")
+            || low.contains("kiogpucommandbuffercallbackerrorimpactinginteractivity")
+    }
+
+    /// Interprets the outer Python wrapper exit / stderr after generation.
+    private static func diagnoseRunnerFailure(
+        exitCode: Int32,
+        stderr: String,
+        modelRepo: String?,
+        textEncoderRepo: String?
+    ) -> String? {
+        let low = stderr.lowercased()
+        let model = modelRepo ?? "(unknown model)"
+        let enc = textEncoderRepo ?? "(unknown text encoder)"
+
+        if low.contains("diagnostic_metal_interactivity")
+            || low.contains("impacting interactivity")
+            || low.contains("kiogpucommandbuffercallbackerrorimpactinginteractivity")
+            || low.contains("kIOGPUCommandBufferCallbackErrorImpactingInteractivity".lowercased())
+        {
+            return metalInteractivityUserHint
+        }
+
+        let looksLikeSigKill = low.contains("sigkill")
+            || low.contains("code -9")
+            || low.contains("signal 9")
+            || low.contains("killed by signal 9")
+            || (low.contains("runtimeerror") && low.contains("-9"))
+        if looksLikeSigKill || exitCode == 137 || exitCode == 9 {
+            return jetsamSigKillUserHint(modelRepo: model, textEncoderRepo: enc)
+        }
+        return nil
+    }
     
     private(set) var isModelLoaded = false
     private var pythonHome: String?
@@ -129,7 +178,18 @@ class LTXBridge {
         let modelRepo = selectedModel.repo
         let selectedTextEncoder = LTXTextEncoderCatalog.resolvedTextEncoder(id: request.textEncoderId)
         let textEncoderRepo = selectedTextEncoder.repo
-        let oomRecoveryHint = "Metal ran out of memory during generation. Retry with safer settings: 512x320 resolution, 25/33/49 frames, 24 FPS, and tiling set to aggressive. Close memory-heavy apps, then retry."
+        guard !textEncoderRepo.isEmpty else {
+            throw LTXError.generationFailed(
+                "Set a text encoder Hugging Face repo in Preferences → General (pick a preset or fill in Custom)."
+            )
+        }
+        let (effectiveTilingMode, appliedTilingRecovery) = GenerationFailureRecovery.effectiveTilingMode(
+            requested: params.vaeTilingMode
+        )
+        if appliedTilingRecovery {
+            progressHandler(0.05, "VAE tiling set to Auto after a previous Metal timeout with Aggressive tiling.")
+        }
+        let oomRecoveryHint = "Metal ran out of memory during generation. Retry with safer settings: 512x320 resolution, 25/33/49 frames, 24 FPS, and VAE tiling set to aggressive. Close memory-heavy apps, then retry."
         let isImageToVideo = request.isImageToVideo
         let modeDescription = isImageToVideo ? "image-to-video" : "text-to-video"
         progressHandler(0.1, "Starting \(modeDescription) (\(selectedModel.displayName))...")
@@ -306,7 +366,7 @@ try:
         "--output-path", "\(outputPath)",
         "--model-repo", model_repo,
         "--text-encoder-repo", text_encoder_repo,
-        "--tiling", "\(params.vaeTilingMode)",
+        "--tiling", "\(effectiveTilingMode)",
     ]
     if negative_prompt.strip():
         cmd.extend(["--negative-prompt", negative_prompt])
@@ -346,6 +406,7 @@ try:
     # flushes is available immediately.  process.stdout.read(n) uses Python's
     # BufferedReader which blocks until n bytes accumulate, starving the progress loop.
     line_buf = ""
+    interactivity_watchdog = False
     download_in_progress = False
     last_download_activity = None  # None = not in download phase yet; set when first download line seen
     # Large models can go quiet between tqdm updates; heartbeats + long window avoid false kills.
@@ -391,6 +452,8 @@ try:
                     continue
                 log(line)
                 low = line.lower()
+                if ("impacting interactivity" in low) or ("kiogpucommandbuffercallbackerrorimpactinginteractivity" in low):
+                    interactivity_watchdog = True
                 if ("fetching" in low) or ("downloading" in low) or line.startswith("DOWNLOAD:") or ("%" in line and "|" in line):
                     download_in_progress = True
                     if last_download_activity is None:
@@ -428,7 +491,22 @@ try:
         if process.returncode < 0:
             signal_num = -process.returncode
             signal_name = signal.Signals(signal_num).name if signal_num in signal.Signals._value2member_map_ else f"signal {signal_num}"
+            if signal_num == signal.SIGKILL:
+                log("DIAGNOSTIC_SIGKILL: mlx_video.generate_av killed by SIGKILL (exit code -9); likely macOS memory pressure during text encoder / model eval.")
+                raise RuntimeError(
+                    "mlx_video.generate_av was killed by SIGKILL (exit code -9). "
+                    "macOS often sends SIGKILL under unified memory pressure (jetsam). "
+                    "Try a smaller text encoder in Preferences, aggressive VAE tiling, lower resolution or frames, or close other apps. "
+                    "Full output is in /tmp/ltx_generation.log."
+                )
             if signal_num == signal.SIGABRT:
+                if interactivity_watchdog:
+                    log("DIAGNOSTIC_METAL_INTERACTIVITY: SIGABRT after Metal Impacting Interactivity watchdog.")
+                    raise RuntimeError(
+                        "DIAGNOSTIC_METAL_INTERACTIVITY: mlx_video.generate_av aborted with SIGABRT (code -6) after "
+                        "[METAL] Impacting Interactivity / kIOGPUCommandBufferCallbackErrorImpactingInteractivity. "
+                        "Try VAE tiling auto or conservative instead of aggressive; reduce resolution or frames."
+                    )
                 raise RuntimeError(
                     "mlx_video.generate_av aborted with SIGABRT (code -6). "
                     "This is usually a native MLX/Metal abort, often from peak unified-memory pressure "
@@ -466,7 +544,12 @@ except Exception as e:
         
         let output: String
         do {
-            output = try await runPython(script: script, timeout: 3600) { stderrChunk in
+            output = try await runPython(
+                script: script,
+                timeout: 3600,
+                generationDiagnostics: (modelRepo: modelRepo, textEncoderRepo: textEncoderRepo),
+                originalVaeTilingMode: request.parameters.vaeTilingMode
+            ) { stderrChunk in
             // Build complete logical lines from chunked stderr reads so STAGE/STATUS tokens
             // are never dropped when a token is split across read boundaries.
             stderrLineBufferLock.lock()
@@ -530,15 +613,39 @@ except Exception as e:
                         failureHintLock.lock()
                         capturedFailureHint = "Detected MLX VAE channel mismatch during decoding. Update with: pip install -U \"mlx-video-with-audio>=0.1.25\". If it persists, your checkpoint may need `embedded_config.json` VAE `timestep_conditioning` — file an issue with logs."
                         failureHintLock.unlock()
-                    } else if lower.contains("kiogpucommandbuffercallbackerrorimpactinginteractivity")
+                    } else if lower.contains("diagnostic_sigkill")
+                                || (lower.contains("sigkill") && lower.contains("-9"))
+                                || lower.contains("code -9")
+                                || lower.contains("signal 9") {
+                        failureHintLock.lock()
+                        capturedFailureHint = Self.jetsamSigKillUserHint(
+                            modelRepo: modelRepo,
+                            textEncoderRepo: textEncoderRepo
+                        )
+                        failureHintLock.unlock()
+                    } else if lower.contains("diagnostic_metal_interactivity")
+                                || lower.contains("kiogpucommandbuffercallbackerrorimpactinginteractivity")
                                 || lower.contains("impacting interactivity") {
                         failureHintLock.lock()
-                        capturedFailureHint = "Metal stopped generation because a command buffer was impacting interactivity. Update with: pip install -U \"mlx-video-with-audio>=0.1.36\" and retry; this version splits large model warmup work into smaller Metal command buffers. If it persists, attach /tmp/ltx_generation.log to the GitHub issue."
+                        capturedFailureHint = Self.metalInteractivityUserHint
                         failureHintLock.unlock()
                         progressHandler(0.01, "Generation stopped: Metal watchdog timeout")
+                        if request.parameters.vaeTilingMode == "aggressive" {
+                            GenerationFailureRecovery.recordMetalInteractivityFailureWithAggressiveTiling()
+                        }
                     } else if lower.contains("sigabrt") || lower.contains("failed with code -6") || lower.contains("aborted with code -6") {
                         failureHintLock.lock()
-                        capturedFailureHint = "The MLX generation process aborted with SIGABRT (code -6). Update with: pip install -U \"mlx-video-with-audio>=0.1.36\" and retry. If it still fails, try 512x320 resolution, 25/33/49 frames, 24 FPS, and aggressive VAE tiling, then attach /tmp/ltx_generation.log to the GitHub issue."
+                        let interactivityLine = lower.contains("impacting interactivity")
+                            || lower.contains("kiogpucommandbuffercallbackerrorimpactinginteractivity")
+                            || (lower.contains("libc++abi") && lower.contains("impacting interactivity"))
+                        if interactivityLine {
+                            capturedFailureHint = Self.metalInteractivityUserHint
+                            if request.parameters.vaeTilingMode == "aggressive" {
+                                GenerationFailureRecovery.recordMetalInteractivityFailureWithAggressiveTiling()
+                            }
+                        } else {
+                            capturedFailureHint = "The MLX generation process aborted with SIGABRT (code -6). Update with: pip install -U \"mlx-video-with-audio>=0.1.36\" and retry. If it still fails, try 512x320 resolution, 25/33/49 frames, 24 FPS, and tuning VAE tiling, then attach /tmp/ltx_generation.log to the GitHub issue."
+                        }
                         failureHintLock.unlock()
                     } else if lower.contains("kiogpucommandbuffercallbackerroroutofmemory")
                                 || lower.contains("insufficient memory")
@@ -655,10 +762,22 @@ except Exception as e:
             failureHintLock.lock()
             let hint = capturedFailureHint
             failureHintLock.unlock()
+            let excerpt = LTXGenerationLogSummary.userFacingExcerpt()
             if let hint, !hint.isEmpty {
-                throw LTXError.generationFailed(hint)
+                LTXGenerationLogSummary.appendToLog(
+                    lines: ["", "=== Swift failure summary ===", hint, "", excerpt]
+                )
+                var full = hint
+                if !excerpt.isEmpty {
+                    full += "\n\n--- Log excerpt ---\n" + excerpt
+                }
+                throw LTXError.generationFailed(full)
             }
-            throw error
+            LTXGenerationLogSummary.appendToLog(
+                lines: ["", "=== Swift failure (no stderr hint) ===", error.localizedDescription, "", excerpt]
+            )
+            let extra = excerpt.isEmpty ? "" : "\n\n--- Log excerpt ---\n" + excerpt
+            throw LTXError.generationFailed(error.localizedDescription + extra)
         }
         
         // Parse JSON output - extract JSON from output (may have other text before it)
@@ -768,6 +887,8 @@ except Exception as e:
     private func runPython(
         script: String,
         timeout: TimeInterval = 60,
+        generationDiagnostics: (modelRepo: String, textEncoderRepo: String)? = nil,
+        originalVaeTilingMode: String? = nil,
         stderrHandler: ((String) -> Void)? = nil
     ) async throws -> String {
         guard let python = pythonExecutable else {
@@ -868,7 +989,31 @@ except Exception as e:
                         if !trimmedOutput.isEmpty && isOnlyHarmless {
                             continuation.resume(returning: trimmedOutput)
                         } else {
-                            continuation.resume(throwing: LTXError.generationFailed("Exit code \(process.terminationStatus). Check /tmp/ltx_generation.log"))
+                            let excerpt = LTXGenerationLogSummary.userFacingExcerpt()
+                            let diagnosed = Self.diagnoseRunnerFailure(
+                                exitCode: process.terminationStatus,
+                                stderr: stderr,
+                                modelRepo: generationDiagnostics?.modelRepo,
+                                textEncoderRepo: generationDiagnostics?.textEncoderRepo
+                            )
+                            if Self.stderrIndicatesMetalInteractivity(stderr),
+                               originalVaeTilingMode == "aggressive" {
+                                GenerationFailureRecovery.recordMetalInteractivityFailureWithAggressiveTiling()
+                            }
+                            var message = diagnosed
+                                ?? "Exit code \(process.terminationStatus). Check /tmp/ltx_generation.log"
+                            if !stderr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                               diagnosed == nil || stderr.count < 12_000 {
+                                message += "\n\n--- Recent stderr ---\n"
+                                    + String(stderr.suffix(8000))
+                            }
+                            if !excerpt.isEmpty {
+                                message += "\n\n--- Log excerpt ---\n" + excerpt
+                            }
+                            LTXGenerationLogSummary.appendToLog(
+                                lines: ["", "=== Swift runner summary ===", message]
+                            )
+                            continuation.resume(throwing: LTXError.generationFailed(message))
                         }
                     } else {
                         continuation.resume(returning: trimmedOutput)

--- a/LTXVideoGenerator/Sources/Services/LTXGenerationLogSummary.swift
+++ b/LTXVideoGenerator/Sources/Services/LTXGenerationLogSummary.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+enum LTXGenerationLogSummary {
+    static let defaultLogPath = "/tmp/ltx_generation.log"
+
+    static func appendToLog(path: String = defaultLogPath, lines: [String]) {
+        let text = lines.joined(separator: "\n") + "\n"
+        guard let data = text.data(using: .utf8) else { return }
+        if FileManager.default.fileExists(atPath: path) {
+            guard let handle = FileHandle(forWritingAtPath: path) else { return }
+            handle.seekToEndOfFile()
+            handle.write(data)
+            try? handle.close()
+        } else {
+            try? data.write(to: URL(fileURLWithPath: path))
+        }
+    }
+
+    /// Tail excerpt prioritizing stderr / native / MLX failure lines for bug reports.
+    static func userFacingExcerpt(path: String = defaultLogPath, maxTailChars: Int = 32_000) -> String {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              !data.isEmpty
+        else {
+            return "(Log missing or empty at \(path).)"
+        }
+        let full = String(data: data, encoding: .utf8) ?? ""
+        let tail = full.count > maxTailChars ? String(full.suffix(maxTailChars)) : full
+        let lines = tail.components(separatedBy: .newlines)
+
+        let keywordPredicates: [(String) -> Bool] = [
+            { $0.contains("[stderr]") },
+            { $0.contains("runtimeerror") },
+            { $0.contains("libc++abi") },
+            { $0.contains("uncaught exception") },
+            { $0.contains("impacting interactivity") },
+            { $0.contains("kiogpucommandbuffer") },
+            { $0.contains("text_encoder") },
+            { $0.contains("eval_chunk") },
+            { $0.contains("sigkill") },
+            { $0.contains("code -9") },
+            { $0.contains("code -6") },
+            { $0.contains("signal 9") },
+            { $0.contains("diagnostic_") },
+        ]
+
+        var matched: [String] = []
+        for line in lines {
+            let low = line.lowercased()
+            if keywordPredicates.contains(where: { $0(low) }) {
+                matched.append(line)
+            }
+        }
+        if matched.count > 16 {
+            matched = Array(matched.suffix(16))
+        }
+
+        let lastSignificant = lines.reversed().first { line in
+            let t = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if t.isEmpty { return false }
+            let low = t.lowercased()
+            return low.contains("error")
+                || low.contains("traceback")
+                || low.contains("failed")
+                || low.contains("exception")
+                || low.contains("metal")
+                || low.contains("sig")
+        } ?? lines.reversed().first { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+
+        var parts: [String] = []
+        if !matched.isEmpty {
+            parts.append("Relevant log lines:\n" + matched.joined(separator: "\n"))
+        }
+        if let last = lastSignificant {
+            parts.append("Last notable line:\n\(last)")
+        }
+        if parts.isEmpty {
+            parts.append(String(tail.suffix(2500)))
+        }
+        return parts.joined(separator: "\n\n")
+    }
+}

--- a/LTXVideoGenerator/Sources/Services/MacOSSystemMemory.swift
+++ b/LTXVideoGenerator/Sources/Services/MacOSSystemMemory.swift
@@ -1,0 +1,34 @@
+import Darwin
+
+/// Host memory stats for lightweight preflight checks (not a guarantee of peak MLX usage).
+enum MacOSSystemMemory {
+    static var physicalMemoryBytes: UInt64 {
+        ProcessInfo.processInfo.physicalMemory
+    }
+
+    /// Approximate currently reusable RAM: free + inactive file-backed pages (vm_statistics64).
+    static func approximateAvailableBytes() -> UInt64 {
+        var stats = vm_statistics64()
+        var count = mach_msg_type_number_t(MemoryLayout<vm_statistics64_data_t>.size / MemoryLayout<integer_t>.size)
+        let result = withUnsafeMutablePointer(to: &stats) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                host_statistics64(mach_host_self(), HOST_VM_INFO64, $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else {
+            return physicalMemoryBytes / 4
+        }
+        let pageSize = UInt64(vm_kernel_page_size)
+        let free = UInt64(stats.free_count) * pageSize
+        let inactive = UInt64(stats.inactive_count) * pageSize
+        return free + inactive
+    }
+
+    static func physicalMemoryGBFormatted() -> String {
+        String(format: "%.0f", Double(physicalMemoryBytes) / 1_073_741_824.0)
+    }
+
+    static func approximateAvailableMemoryGBFormatted() -> String {
+        String(format: "%.1f", Double(approximateAvailableBytes()) / 1_073_741_824.0)
+    }
+}

--- a/LTXVideoGenerator/Sources/Views/ParametersView.swift
+++ b/LTXVideoGenerator/Sources/Views/ParametersView.swift
@@ -283,7 +283,7 @@ struct ParametersView: View {
                         }
                         .labelsHidden()
                         
-                        Text("Controls memory vs speed tradeoff during decoding. Aggressive uses less memory; Conservative is faster but needs more memory.")
+                        Text("Controls memory vs speed tradeoff during decoding. Aggressive reduces peak memory but can trigger macOS Metal “Impacting Interactivity” watchdogs on small resolutions; use Auto or Conservative if that happens.")
                             .font(.caption2)
                             .foregroundStyle(.tertiary)
                     }

--- a/LTXVideoGenerator/Sources/Views/PreferencesView.swift
+++ b/LTXVideoGenerator/Sources/Views/PreferencesView.swift
@@ -13,6 +13,7 @@ struct PreferencesView: View {
     @AppStorage("useLocalMlxVideoRepo") private var useLocalMlxVideoRepo = false
     @AppStorage(LTXModelCatalog.selectedModelIDKey) private var selectedModelID = LTXModelCatalog.defaultModelID
     @AppStorage(LTXTextEncoderCatalog.selectedTextEncoderIDKey) private var selectedTextEncoderID = LTXTextEncoderCatalog.defaultTextEncoderID
+    @AppStorage(LTXTextEncoderCatalog.customTextEncoderRepoKey) private var customTextEncoderRepo = ""
 
     @State private var pythonStatus: (success: Bool, message: String)?
     @State private var pythonDetails: PythonDetails?
@@ -286,6 +287,18 @@ struct PreferencesView: View {
                                 .foregroundStyle(.orange)
                             Text(qualityWarning)
                                 .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    if selectedTextEncoderID == "custom" {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Custom text encoder repo (Hugging Face id)")
+                                .font(.caption.bold())
+                            TextField("e.g. mlx-community/gemma-3-12b-it-4bit", text: $customTextEncoderRepo)
+                                .textFieldStyle(.roundedBorder)
+                            Text("The app does not download weights until you run a generation. Use any MLX-compatible Gemma repo your Python environment supports.")
+                                .font(.caption2)
                                 .foregroundStyle(.secondary)
                         }
                     }

--- a/LTXVideoGenerator/Sources/Views/PromptInputView.swift
+++ b/LTXVideoGenerator/Sources/Views/PromptInputView.swift
@@ -46,6 +46,7 @@ struct PromptInputView: View {
     @State private var previewError: String?
     @State private var previewStatusMessage = ""
     @State private var showMemoryRiskAlert = false
+    @State private var dismissedHeavyEncoderComboHint = false
     @State private var pendingQueueAction: PendingQueueAction?
     @State private var showSaveCharacterProfile = false
     @State private var newCharacterProfileName = ""
@@ -81,6 +82,17 @@ struct PromptInputView: View {
             ? ""
             : " Switch tiling to aggressive for lower peak memory."
         return "This request may hit Metal memory limits (estimated ~\(estimatedMemoryGB)GB on a ~\(machineMemoryGB)GB machine). Recommended retry settings: 512x320 resolution, 25/33/49 frames, 24 FPS.\(tilingHint)"
+    }
+
+    /// Non-blocking preflight: very large bf16 stacks on small unified-memory Macs (#53).
+    private var heavyEncoderCombinationWarning: String? {
+        let physGB = Int(MacOSSystemMemory.physicalMemoryBytes / 1_073_741_824)
+        let avail = MacOSSystemMemory.approximateAvailableMemoryGBFormatted()
+        let model = selectedModel
+        let isLargeBf16Unified = model.id == "ltx2_unified" || model.id == "ltx23_unified"
+        let is12bBf16Encoder = selectedTextEncoderID == "gemma3_12b_bf16"
+        guard isLargeBf16Unified, is12bBf16Encoder, physGB < 32 else { return nil }
+        return "This pairing (large unified LTX bf16 model + Gemma 12B bf16 text encoder) often needs on the order of 50 GB unified memory during TEXT_ENCODER. Your Mac has about \(physGB) GB physical memory (~\(avail) GB available, approximate). Prefer Gemma 4B bf16 or 4-bit (Preferences → General → Text Encoder), enable aggressive VAE tiling, or fewer pixels/frames. You can still generate."
     }
 
     private var selectedVoiceId: String {
@@ -518,6 +530,29 @@ struct PromptInputView: View {
                 }
             }
             
+            if let heavyHint = heavyEncoderCombinationWarning, !dismissedHeavyEncoderComboHint {
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                    Text(heavyHint)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Spacer(minLength: 8)
+                    Button("Dismiss") {
+                        dismissedHeavyEncoderComboHint = true
+                    }
+                    .buttonStyle(.borderless)
+                    .controlSize(.small)
+                }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color.orange.opacity(0.08))
+                )
+            }
+
             // Quick actions
             HStack(spacing: 12) {
                 // Generate button - changes appearance based on state
@@ -661,6 +696,10 @@ struct PromptInputView: View {
             if !selectedModel.supportsBuiltInAudio {
                 disableAudio = false
             }
+            dismissedHeavyEncoderComboHint = false
+        }
+        .onChange(of: selectedTextEncoderID) { _, _ in
+            dismissedHeavyEncoderComboHint = false
         }
         .alert("High Memory Risk", isPresented: $showMemoryRiskAlert) {
             Button("Continue Anyway") {

--- a/docs/issue-comments/48.md
+++ b/docs/issue-comments/48.md
@@ -1,0 +1,17 @@
+Thanks for reporting this — the traceback you pasted is the classic **Metal “Impacting Interactivity”** path, and your settings match what we have seen in the wild.
+
+**What is going wrong**
+
+`RuntimeError` / `libc++abi` with `[METAL] Command buffer execution failed: Impacting Interactivity` means the **WindowServer / GPU watchdog** decided a **single Metal command buffer ran too long**. That is not the same as running out of unified memory: it is a **time budget** problem. It shows up often with **`--tiling aggressive`** on **small spatial resolutions** (e.g. 320×320) or on slower GPUs, because the workload is sliced in a way that can keep one buffer “hot” for too long.
+
+**What you can do today**
+
+- Set VAE tiling to **auto** or **conservative** (avoid **aggressive** if you hit this).
+- Lower **resolution** and/or **frame count** slightly and retry.
+- Stay current on **mlx-video-with-audio** (the stack has been iterating on smaller command buffers for warmup-style work).
+
+**What we changed in the app**
+
+In **2.3.60** the app explains this failure mode explicitly (including pointing away from **aggressive** tiling when this error appears). If a run fails with this pattern while **Aggressive** tiling was selected, the **next** generation automatically falls back to **Auto** tiling once (with a one-line status hint) until a run completes successfully — so retries are less painful.
+
+If you still see the watchdog after switching tiling, attach `/tmp/ltx_generation.log` from one failing run.

--- a/docs/issue-comments/53.md
+++ b/docs/issue-comments/53.md
@@ -1,0 +1,17 @@
+Thanks for the detailed repro — that lines up with what we see when the OS runs out of headroom during the Gemma text encoder phase.
+
+**What is going wrong**
+
+The Python child that runs `python -m mlx_video.generate_av` is not “crashing” in the Python sense; it is being **sent SIGKILL (-9)** by macOS. That almost always means **memory pressure / jetsam**: the combination of a full unified AV checkpoint plus Gemma 3 12B in bf16 spikes unified memory high enough during `TEXT_ENCODER:EVAL_CHUNK` that the system terminates the process to keep the machine responsive.
+
+**What you can do today**
+
+- In **Preferences → General → Text Encoder**, switch to **Gemma 4B bf16** or **Gemma 12B 4-bit** (or a custom smaller MLX Gemma repo you trust).
+- In generation parameters, use **aggressive** VAE tiling if you are memory-bound, and reduce **resolution** and **frame count**.
+- Quit other heavy apps before generating.
+
+**What we changed in the app**
+
+The next release (**2.3.60**) translates SIGKILL / code -9 into a clear in-app message and appends a focused excerpt (stderr / `RuntimeError` / `libc++abi` lines where present) to `/tmp/ltx_generation.log`, including approximate RAM and the model/encoder ids so bug reports are easier. A **non-blocking** banner also warns when a large unified bf16 model is paired with Gemma 12B bf16 on Macs with under 32 GB RAM.
+
+If anything still fails after trying a smaller encoder, attach `/tmp/ltx_generation.log` from a single run.


### PR DESCRIPTION
## Summary

Release **v2.3.60** with generation-runtime hardening for SIGKILL/jetsam during text encoder work and Metal interactivity failures when using aggressive VAE tiling.

## Per-issue root cause and fix

- **#53 — SIGKILL / jetsam during text encoder** — The Python subprocess could be killed by memory pressure (-9) without a clear explanation. The app now detects SIGKILL, surfaces guidance (smaller Gemma encoder, tiling, resolution/frames, closing other apps) with approximate free RAM and model/encoder context, and appends a stderr-focused excerpt to `/tmp/ltx_generation.log`.
- **#48 — Metal impacting interactivity with aggressive tiling** — Metal watchdog / `kIOGPUCommandBufferCallbackErrorImpactingInteractivity` (-6) could abort runs with aggressive tiling. The app explains the tradeoff, and after an aggressive-tiling failure it automatically switches VAE tiling to **Auto** for one run (persisted hint via `UserDefaults`) until a generation succeeds.

## Verification

Full **xcodebuild** is not available: `xcode-select` points at **Command Line Tools** (`/Library/Developer/CommandLineTools`), and `xcodebuild` reports that Xcode is required.

**Fallback:** syntax-only check with `swiftc -parse` on the Swift sources touched on this branch vs `main`:

- `LTXVideoGenerator/Sources/Models/GenerationRequest.swift`
- `LTXVideoGenerator/Sources/Services/GenerationFailureRecovery.swift`
- `LTXVideoGenerator/Sources/Services/GenerationService.swift`
- `LTXVideoGenerator/Sources/Services/LTXBridge.swift`
- `LTXVideoGenerator/Sources/Services/LTXGenerationLogSummary.swift`
- `LTXVideoGenerator/Sources/Services/MacOSSystemMemory.swift`
- `LTXVideoGenerator/Sources/Views/ParametersView.swift`
- `LTXVideoGenerator/Sources/Views/PreferencesView.swift`
- `LTXVideoGenerator/Sources/Views/PromptInputView.swift`

All passed.

Closes #53
Closes #48
