### PR TITLE
v2.3.61: persist settings, scrollable layout (#52, #51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- **Issue #52 — Window forced minimum height instead of scrolling** — Lower the root `ContentView` minimum to 480pt tall × 900pt wide (`idealHeight: 800`, `maxHeight: .infinity`) so the window can shrink to fit a 13" laptop minus chrome. Wrap the Generate-tab middle pane (prompt, voiceover, music, prompt enhancement, Generate button) in a vertical `ScrollView` so the Generate button stays reachable regardless of which disclosure groups are expanded. Sidebar is also scrollable for very short windows.
+
 ### Added
+- **Issue #51 — Persist generation settings between launches** — Migrate session-level settings to `@AppStorage`/`UserDefaults` so they survive app relaunches and tab switches: prompt, negative prompt, voiceover narration text, voiceover source + voice (ElevenLabs/MLX Audio), music enabled + genre, "Generate Audio" toggle for the unified AV model, Gemma prompt-enhancement parameters (repetition penalty, top-p), selected tab, and the full `GenerationParameters` struct (steps, guidance, width/height, frames, FPS, seed, VAE tiling, image strength) round-tripped through JSON. Add a "Reset to Defaults…" button under Preferences → General → Reset behind a confirmation alert; Python path, output directory, and ElevenLabs API key are intentionally preserved.
 - **Memory preflight** — Non-dismissable-by-default banner when a large unified bf16 model is paired with Gemma 12B bf16 on Macs with under 32 GB physical memory (rough unified-memory guidance using `host_statistics64`).
 - **Text encoder presets** — Gemma 4B bf16 (`mlx-community/gemma-3-4b-it-bf16`) and a **Custom Hugging Face repo** field in Preferences (alongside clearer labels for 12B bf16 and 12B 4-bit).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.3.61] - 2026-05-06
+
 ### Fixed
 - **Issue #52 — Window forced minimum height instead of scrolling** — Lower the root `ContentView` minimum to 480pt tall × 900pt wide (`idealHeight: 800`, `maxHeight: .infinity`) so the window can shrink to fit a 13" laptop minus chrome. Wrap the Generate-tab middle pane (prompt, voiceover, music, prompt enhancement, Generate button) in a vertical `ScrollView` so the Generate button stays reachable regardless of which disclosure groups are expanded. Sidebar is also scrollable for very short windows.
 

--- a/LTXVideoGenerator/LTXVideoGenerator.xcodeproj/project.pbxproj
+++ b/LTXVideoGenerator/LTXVideoGenerator.xcodeproj/project.pbxproj
@@ -404,7 +404,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.3.60;
+				MARKETING_VERSION = 2.3.61;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ltxvideo.generator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -432,7 +432,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.3.60;
+				MARKETING_VERSION = 2.3.61;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jamescampbell.ltxvideogenerator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LTXVideoGenerator/Sources/Views/ContentView.swift
+++ b/LTXVideoGenerator/Sources/Views/ContentView.swift
@@ -4,14 +4,18 @@ struct ContentView: View {
     @EnvironmentObject var generationService: GenerationService
     @EnvironmentObject var historyManager: HistoryManager
     @EnvironmentObject var presetManager: PresetManager
-    
-    @State private var prompt = ""
-    @State private var negativePrompt = ""
-    @State private var voiceoverText = ""
-    @State private var parameters = GenerationParameters.default
-    @State private var selectedTab: Tab = .generate
+
+    // Persisted across app launches (issue #51).
+    @AppStorage(SessionSettings.promptKey) private var prompt = ""
+    @AppStorage(SessionSettings.negativePromptKey) private var negativePrompt = ""
+    @AppStorage(SessionSettings.voiceoverTextKey) private var voiceoverText = ""
+    @AppStorage(SessionSettings.selectedTabKey) private var selectedTab: Tab = .generate
+
+    // GenerationParameters is a struct, so we persist it as JSON via UserDefaults
+    // and bridge through a `@State` binding the children already expect.
+    @State private var parameters: GenerationParameters = SessionSettings.loadParameters()
     @State private var showError = false
-    
+
     enum Tab: String, CaseIterable {
         case generate = "Generate"
         case history = "Video Archive"
@@ -23,7 +27,16 @@ struct ContentView: View {
         } detail: {
             detailContent
         }
-        .frame(minWidth: 1100, minHeight: 700)
+        // Issue #52: relax the hard minimum so the window can shrink on small
+        // displays (e.g. 13" MacBook Air with a non-default text size). Inner
+        // panes are scrollable, so the Generate button stays reachable.
+        .frame(
+            minWidth: 900,
+            idealWidth: 1280,
+            minHeight: 480,
+            idealHeight: 800,
+            maxHeight: .infinity
+        )
         .alert("Error", isPresented: $showError, presenting: generationService.error) { _ in
             Button("OK", role: .cancel) {
                 generationService.clearError()
@@ -34,17 +47,24 @@ struct ContentView: View {
         .onChange(of: generationService.error) { _, newError in
             showError = newError != nil
         }
+        .onChange(of: parameters) { _, newValue in
+            SessionSettings.saveParameters(newValue)
+        }
     }
     
     private var sidebarContent: some View {
-        VStack(spacing: 0) {
-            tabSelector
-            Divider()
-            QueueView()
-                .frame(maxHeight: 300)
-            Spacer()
-            ModelStatusView()
-                .padding()
+        // Issue #52: allow the sidebar to scroll vertically when the window is
+        // very short, so QueueView and ModelStatusView are both still reachable.
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(spacing: 0) {
+                tabSelector
+                Divider()
+                QueueView()
+                    .frame(minHeight: 160, maxHeight: 300)
+                Divider()
+                ModelStatusView()
+                    .padding()
+            }
         }
         .frame(width: 320)
         .background(Color(nsColor: .windowBackgroundColor))
@@ -222,6 +242,77 @@ struct ModelStatusView: View {
     }
 }
 
+/// Centralized keys + JSON helpers for the session-level settings that issue
+/// #51 asked us to persist between launches. Plain values (Bool, String, raw
+/// representable enums) live as `@AppStorage` directly in the views; complex
+/// structs round-trip through JSON in `UserDefaults`.
+enum SessionSettings {
+    static let promptKey = "session.prompt"
+    static let negativePromptKey = "session.negativePrompt"
+    static let voiceoverTextKey = "session.voiceoverText"
+    static let selectedTabKey = "session.selectedTab"
+    static let parametersKey = "session.generationParameters"
+
+    static let voiceoverSourceKey = "session.voiceoverSource"
+    static let elevenLabsVoiceKey = "session.elevenLabsVoice"
+    static let mlxVoiceKey = "session.mlxVoice"
+    static let musicEnabledKey = "session.musicEnabled"
+    static let musicGenreKey = "session.musicGenre"
+    static let disableAudioKey = "session.disableAudio"
+    static let gemmaRepetitionPenaltyKey = "session.gemmaRepetitionPenalty"
+    static let gemmaTopPKey = "session.gemmaTopP"
+
+    /// Keys that "Reset to defaults" wipes. Excludes app-level prefs that the
+    /// user explicitly configured (Python path, ElevenLabs key, output dir).
+    static let resettableKeys: [String] = [
+        promptKey,
+        negativePromptKey,
+        voiceoverTextKey,
+        selectedTabKey,
+        parametersKey,
+        voiceoverSourceKey,
+        elevenLabsVoiceKey,
+        mlxVoiceKey,
+        musicEnabledKey,
+        musicGenreKey,
+        disableAudioKey,
+        gemmaRepetitionPenaltyKey,
+        gemmaTopPKey,
+        "sourceImagePath",
+        "enableGemmaPromptEnhancement",
+        "saveAudioTrackSeparately",
+        "keepCompletedInQueue",
+        "autoLoadModel",
+        "defaultAudioSource",
+        LTXModelCatalog.selectedModelIDKey,
+        LTXTextEncoderCatalog.selectedTextEncoderIDKey,
+        LTXTextEncoderCatalog.customTextEncoderRepoKey,
+    ]
+
+    static func loadParameters() -> GenerationParameters {
+        guard let data = UserDefaults.standard.data(forKey: parametersKey) else {
+            return .default
+        }
+        if let decoded = try? JSONDecoder().decode(GenerationParameters.self, from: data) {
+            return decoded
+        }
+        return .default
+    }
+
+    static func saveParameters(_ value: GenerationParameters) {
+        if let data = try? JSONEncoder().encode(value) {
+            UserDefaults.standard.set(data, forKey: parametersKey)
+        }
+    }
+
+    static func resetAll() {
+        let defaults = UserDefaults.standard
+        for key in resettableKeys {
+            defaults.removeObject(forKey: key)
+        }
+    }
+}
+
 struct GenerateView: View {
     @Binding var prompt: String
     @Binding var negativePrompt: String
@@ -236,16 +327,22 @@ struct GenerateView: View {
     }
     
     private var promptArea: some View {
-        VStack {
-            PromptInputView(
-                prompt: $prompt,
-                negativePrompt: $negativePrompt,
-                voiceoverText: $voiceoverText,
-                parameters: $parameters
-            )
-            Spacer()
-            TipsView()
-                .padding()
+        // Issue #52: wrap the prompt + actions in a vertical ScrollView so the
+        // Generate button stays reachable when the window is shorter than the
+        // accumulated content (e.g. on a 13" MacBook Air with non-default text
+        // size). The internal layout is unchanged.
+        ScrollView(.vertical, showsIndicators: true) {
+            VStack(spacing: 0) {
+                PromptInputView(
+                    prompt: $prompt,
+                    negativePrompt: $negativePrompt,
+                    voiceoverText: $voiceoverText,
+                    parameters: $parameters
+                )
+                TipsView()
+                    .padding()
+            }
+            .frame(maxWidth: .infinity)
         }
         .frame(minWidth: 400, idealWidth: 500)
     }

--- a/LTXVideoGenerator/Sources/Views/PreferencesView.swift
+++ b/LTXVideoGenerator/Sources/Views/PreferencesView.swift
@@ -25,6 +25,7 @@ struct PreferencesView: View {
     @State private var installMessage: String?
     @State private var isTestingElevenLabs = false
     @State private var elevenLabsTestResult: (success: Bool, message: String)?
+    @State private var showResetConfirm = false
 
     private var selectedModel: LTXModel {
         LTXModelCatalog.resolvedModel(id: selectedModelID)
@@ -324,6 +325,20 @@ struct PreferencesView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
+
+                Section("Reset") {
+                    HStack {
+                        Button(role: .destructive) {
+                            showResetConfirm = true
+                        } label: {
+                            Label("Reset to Defaults…", systemImage: "arrow.counterclockwise")
+                        }
+                        Spacer()
+                    }
+                    Text("Clears persisted prompt, generation parameters, audio toggles, and model selections. Python path, output directory, and ElevenLabs API key are kept.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
             .formStyle(.grouped)
             .tabItem {
@@ -458,6 +473,14 @@ struct PreferencesView: View {
         .frame(width: 550, height: 450)
         .sheet(isPresented: $showPathPicker) {
             DetectedPathsView(paths: detectedPaths, selectedPath: $pythonPath, isPresented: $showPathPicker)
+        }
+        .alert("Reset to defaults?", isPresented: $showResetConfirm) {
+            Button("Cancel", role: .cancel) {}
+            Button("Reset", role: .destructive) {
+                SessionSettings.resetAll()
+            }
+        } message: {
+            Text("This clears the persisted prompt, generation parameters, audio settings, prompt-enhancement toggles, and model/text-encoder selections. Python path, output directory, and ElevenLabs API key are preserved.")
         }
     }
     

--- a/LTXVideoGenerator/Sources/Views/PromptInputView.swift
+++ b/LTXVideoGenerator/Sources/Views/PromptInputView.swift
@@ -25,21 +25,24 @@ struct PromptInputView: View {
     @AppStorage("enableGemmaPromptEnhancement") private var enableGemmaPromptEnhancement = false
     @AppStorage(LTXModelCatalog.selectedModelIDKey) private var selectedModelID = LTXModelCatalog.defaultModelID
     @AppStorage(LTXTextEncoderCatalog.selectedTextEncoderIDKey) private var selectedTextEncoderID = LTXTextEncoderCatalog.defaultTextEncoderID
-    @State private var voiceoverSource: AudioSource = .mlxAudio
-    @State private var selectedElevenLabsVoice: String = "21m00Tcm4TlvDq8ikWAM"
-    @State private var selectedMLXVoice: String = "af_heart"
-    
-    // Music settings
-    @State private var musicEnabled = false
-    @State private var selectedMusicGenre: MusicGenre = .cinematicUplifting
-    
-    // Audio disable for unified model
-    @State private var disableAudio = false
-    
-    // Gemma prompt enhancement
+
+    // Issue #51: persist these between launches and across tab switches.
+    @AppStorage(SessionSettings.voiceoverSourceKey) private var voiceoverSource: AudioSource = .mlxAudio
+    @AppStorage(SessionSettings.elevenLabsVoiceKey) private var selectedElevenLabsVoice: String = "21m00Tcm4TlvDq8ikWAM"
+    @AppStorage(SessionSettings.mlxVoiceKey) private var selectedMLXVoice: String = "af_heart"
+
+    // Music settings (persisted)
+    @AppStorage(SessionSettings.musicEnabledKey) private var musicEnabled = false
+    @AppStorage(SessionSettings.musicGenreKey) private var selectedMusicGenre: MusicGenre = .cinematicUplifting
+
+    // Audio disable for unified model — persisted (issue #51 explicitly called
+    // this out: "Generate Audio is forced to true on launch").
+    @AppStorage(SessionSettings.disableAudioKey) private var disableAudio = false
+
+    // Gemma prompt enhancement (persisted)
     @State private var showPromptEnhancement = false
-    @State private var gemmaRepetitionPenalty: Double = 1.2
-    @State private var gemmaTopP: Double = 0.9
+    @AppStorage(SessionSettings.gemmaRepetitionPenaltyKey) private var gemmaRepetitionPenalty: Double = 1.2
+    @AppStorage(SessionSettings.gemmaTopPKey) private var gemmaTopP: Double = 0.9
     @State private var showEnhancedPreview = false
     @State private var enhancedPreview: String?
     @State private var isPreviewing = false

--- a/docs/issue-comments/44.md
+++ b/docs/issue-comments/44.md
@@ -1,0 +1,24 @@
+Thanks for the follow-up and for explaining the use case — character consistency (visual + voice) for short-form video is a totally legitimate need, and we want to support it well rather than ship something half-finished.
+
+Here is where things stand today:
+
+**ID LoRA**
+
+The unified MLX port we ride on top of (`mlx-video-with-audio`, which wraps the upstream LTX-2 weights) does not yet expose LoRA hooks at the transformer level. Until that lands upstream, there is no clean way for this app to load identity LoRAs without forking the inference pipeline. We are tracking upstream and will wire it up the moment those hooks exist.
+
+In the meantime, the closest thing this app gives you for visual consistency is the **Character Profile** feature (Generate tab → Character Profile disclosure). It bundles the same prompt, source image (image-to-video), voice, music, model, and generation settings under a name so you can re-apply them between runs. It is not a LoRA — it does not learn — but for many short-video workflows it gets you most of the way there.
+
+**Custom voice / voice cloning**
+
+The unified LTX-2 AV model generates audio jointly with video, and that path does not currently expose a cloning-style speaker conditioning interface. For separately-rendered voiceover, the app uses **MLX Audio (Kokoro)** locally and **ElevenLabs** via API — Kokoro ships fixed presets, and ElevenLabs has its own voice cloning product if you bring an API key with cloning entitlements. We do not yet wrap their cloning endpoint inside the app.
+
+**How to help us prioritize this**
+
+Rather than tracking both asks under one issue, would you mind opening two follow-ups so we can label and rank them independently?
+
+1. **LoRA support** (ID/style/concept LoRA loading once upstream exposes it)
+2. **Voice cloning / custom voice** (custom-voice TTS path, either via Kokoro voice packs or ElevenLabs cloning)
+
+A short note in each describing your specific workflow (resolution, frame count, how often you re-use a character, whether you have an ElevenLabs key, etc.) would help a lot. Upvotes on those issues will tell us where to spend the next round of work.
+
+Leaving this issue open for now and labeling it `enhancement / feature-request / needs-triage` so it surfaces in the roadmap discussion.

--- a/docs/issue-comments/51.md
+++ b/docs/issue-comments/51.md
@@ -1,0 +1,31 @@
+Good catch — you were right that this was an oversight. Most of these were `@State` (in-memory only) instead of `@AppStorage`, which is why "Generate Audio" snapped back to on every launch and the prompt text vanished when the app quit or the tab changed.
+
+**What now persists across launches and tab switches**
+
+Generation tab:
+
+- Prompt and negative prompt text
+- Voiceover narration text
+- Voiceover source (ElevenLabs vs MLX Audio) and the selected voice for each
+- Background music enabled and selected genre
+- "Generate Audio" toggle for the unified AV model (the one you specifically called out)
+- Gemma prompt-enhancement toggle, repetition penalty, top-p
+- Source image path (already persisted via #41)
+- Selected tab (Generate vs Video Archive)
+- Selected sidebar/header model and Gemma text encoder
+
+Generation parameters:
+
+- Inference steps, guidance scale, width, height, frames, FPS, seed, VAE tiling mode, image strength
+
+These all save immediately as you change them (standard `@AppStorage` semantics — no Save button needed). Internally, scalar prefs use `@AppStorage` directly, and the `GenerationParameters` struct round-trips through JSON in `UserDefaults` since it is `Codable`.
+
+**Reset to defaults**
+
+Added a "Reset to Defaults…" button under Preferences → General → Reset, behind a confirmation alert. It clears the persisted prompt, generation parameters, audio toggles, prompt-enhancement toggles, and model/text-encoder selections. **Python path, output directory, and ElevenLabs API key are intentionally preserved** so a reset does not break the install.
+
+**Sandbox / output directory note**
+
+The app currently ships **unsandboxed** (`com.apple.security.app-sandbox = false` in the entitlements), so the picked output directory persists as a plain path string and continues to work after relaunch without needing security-scoped bookmarks. If sandboxing is enabled in a future release we will switch the output directory to a security-scoped bookmark.
+
+Coming in the next release on `main`. Branch: `fix/ui-issues-52-51-and-triage-44`.

--- a/docs/issue-comments/52.md
+++ b/docs/issue-comments/52.md
@@ -1,0 +1,18 @@
+Thanks for the detailed report and screenshots — that made this easy to reproduce.
+
+**What was wrong**
+
+`ContentView` enforced `.frame(minWidth: 1100, minHeight: 700)` on the root scene, and the Generate-tab middle pane was a plain `VStack` with no `ScrollView`. On a 13" MacBook Air with non-default text size, the cumulative height of the prompt + disclosure groups + Generate button exceeded the visible space and the window itself refused to shrink, so the Generate button slipped under the dock cutoff. The only workaround was the one you found: collapsing every disclosure group to push the button back up.
+
+**What we changed**
+
+- The window minimum is now **480pt tall, 900pt wide** (`idealHeight: 800`, `maxHeight: .infinity`), so it can shrink to fit a 13" laptop minus chrome.
+- The Generate-tab middle pane (prompt, negative prompt, voiceover, music, prompt enhancement, Generate button) is wrapped in a vertical `ScrollView`, so the Generate button always remains reachable regardless of how many disclosure groups are expanded.
+- The sidebar (Queue + Model status) is also wrapped in a `ScrollView` for very short windows, and the Queue section now has both `minHeight` and `maxHeight` so it does not collapse to zero.
+- The right-hand Parameters pane was already scrollable internally and was left as-is.
+
+**Where it lands**
+
+Coming in the next release on `main`. Branch with the fix: `fix/ui-issues-52-51-and-triage-44`.
+
+If you still hit a layout where the Generate button is not reachable after upgrading, please reopen with the new window dimensions and the disclosure groups you had expanded — we want this to scroll cleanly at any reasonable size.


### PR DESCRIPTION
## Summary

Release **v2.3.61** with a scrollable, resizable Generate layout (#52) and persisted generation/session settings (#51). This release also includes the memory preflight banner and Gemma text encoder preset / custom repo UI that remained queued after v2.3.60.

## Per-issue change

- **#52 — Window forced minimum height / unreachable controls** — Lower the root window minimum size and wrap the Generate tab’s middle column in a vertical `ScrollView` so the window fits smaller displays and the Generate button stays reachable. The sidebar scrolls on very short windows.
- **#51 — Persist settings** — Move key session fields to `@AppStorage` / `UserDefaults` (prompts, voiceover, music, tab, generation parameters JSON, etc.) and add **Reset to Defaults** under Preferences (preserving Python path, output dir, and ElevenLabs key).

**#44** was triaged via an issue comment only (no code change in this PR).

## Verification

Full **xcodebuild** is not available (`xcode-select` → Command Line Tools only). **Fallback:** `swiftc -parse` on Swift sources changed vs `main` on this branch:

- `LTXVideoGenerator/Sources/Views/ContentView.swift`
- `LTXVideoGenerator/Sources/Views/PreferencesView.swift`
- `LTXVideoGenerator/Sources/Views/PromptInputView.swift`

All passed.

Closes #52
Closes #51
