### PR TITLE
fix(build): import Foundation in MacOSSystemMemory

### DIFF
--- a/LTXVideoGenerator/Sources/Services/MacOSSystemMemory.swift
+++ b/LTXVideoGenerator/Sources/Services/MacOSSystemMemory.swift
@@ -1,4 +1,5 @@
 import Darwin
+import Foundation
 
 /// Host memory stats for lightweight preflight checks (not a guarantee of peak MLX usage).
 enum MacOSSystemMemory {


### PR DESCRIPTION
## Summary
- `MacOSSystemMemory.swift` only imported `Darwin`, but uses `ProcessInfo` which lives in `Foundation`.
- Older SDKs pulled `Foundation` in transitively; on the **macOS 26.4 SDK** (Xcode 26) it doesn't, so Release builds fail with:
  ```
  error: cannot find 'ProcessInfo' in scope
  ```
- One-line fix: add `import Foundation`.

## Test plan
- [x] `xcodebuild -scheme LTXVideoGenerator -configuration Release ... build` succeeds locally on macOS 26.4 SDK after the patch (fails without it).
- [ ] CI archive on the maintainer's machine still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)