### PR TITLE
Fix queue, cancellation, and oversized error dialog

### DIFF
--- a/LTXVideoGenerator/Sources/Services/GenerationService.swift
+++ b/LTXVideoGenerator/Sources/Services/GenerationService.swift
@@ -300,8 +300,10 @@ class GenerationService: ObservableObject {
             statusMessage = "Video saved to \(outputDir)"
             
         } catch is CancellationError {
+            // User-initiated cancel — stop quietly, no error popup.
             queue[index].status = .cancelled
-            error = .cancelled
+        } catch let err as LTXError where err == .cancelled {
+            queue[index].status = .cancelled
         } catch let err as LTXError {
             queue[index].status = .failed
             error = err

--- a/LTXVideoGenerator/Sources/Services/LTXBridge.swift
+++ b/LTXVideoGenerator/Sources/Services/LTXBridge.swift
@@ -23,6 +23,38 @@ enum LTXError: LocalizedError, Equatable {
     }
 }
 
+/// Thread-safe holder so a Task-cancellation handler can terminate the running
+/// generation subprocess even though it is created on a background dispatch queue.
+private final class CancellableProcessHolder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var process: Process?
+    private var cancelledFlag = false
+
+    /// Store the process. Returns false if cancellation already happened, in
+    /// which case the caller should not start the process.
+    func storeIfNotCancelled(_ p: Process) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        if cancelledFlag { return false }
+        process = p
+        return true
+    }
+
+    /// Mark cancelled and terminate the process (SIGTERM). The Python wrapper's
+    /// signal handler forwards SIGKILL to the whole child process group.
+    func cancel() {
+        lock.lock()
+        cancelledFlag = true
+        let p = process
+        lock.unlock()
+        p?.terminate()
+    }
+
+    var wasCancelled: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return cancelledFlag
+    }
+}
+
 // Use subprocess to run MLX-based generation
 class LTXBridge {
     static let shared = LTXBridge()
@@ -394,14 +426,33 @@ try:
     if use_local_mlx_video_repo:
         child_env["PYTHONPATH"] = local_mlx_video_repo
     
-    # Run the CLI module and stream combined output (binary read so we see tqdm \\r updates)
+    # Run the CLI module and stream combined output (binary read so we see tqdm \\r updates).
+    # start_new_session=True puts the child (and anything it spawns) in its own
+    # process group so we can terminate the whole tree atomically on cancel.
     process = subprocess.Popen(
         cmd,
         env=child_env,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
     )
-    
+
+    # When the app cancels generation it sends this wrapper SIGTERM. Forward that
+    # to the entire child process group (SIGKILL) so the heavy mlx_video process
+    # actually dies instead of being orphaned and holding the GPU/memory.
+    def _terminate_child(signum, frame):
+        try:
+            os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+        except Exception:
+            try:
+                process.kill()
+            except Exception:
+                pass
+        os._exit(1)
+
+    signal.signal(signal.SIGTERM, _terminate_child)
+    signal.signal(signal.SIGINT, _terminate_child)
+
     # Unbuffered read: use os.read() on the raw fd so every line the inner process
     # flushes is available immediately.  process.stdout.read(n) uses Python's
     # BufferedReader which blocks until n bytes accumulate, starving the progress loop.
@@ -896,8 +947,11 @@ except Exception as e:
         }
         
         let logFile = "/tmp/ltx_generation.log"
-        
-        return try await withCheckedThrowingContinuation { continuation in
+
+        let holder = CancellableProcessHolder()
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
                 let process = Process()
                 process.executableURL = URL(fileURLWithPath: python)
@@ -951,12 +1005,25 @@ except Exception as e:
                     }
                 }
                 
+                // If the task was cancelled before we could start, abort now.
+                guard holder.storeIfNotCancelled(process) else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+
                 do {
                     let startLog = "=== LTX MLX Process Started ===\nPython: \(python)\nTime: \(Date())\n"
                     try? startLog.write(toFile: logFile, atomically: false, encoding: .utf8)
-                    
+
                     try process.run()
                     process.waitUntilExit()
+
+                    // User-initiated cancel: surface as cancellation, not a failure.
+                    if holder.wasCancelled {
+                        stderrPipe.fileHandleForReading.readabilityHandler = nil
+                        continuation.resume(throwing: CancellationError())
+                        return
+                    }
                     
                     stderrPipe.fileHandleForReading.readabilityHandler = nil
                     
@@ -1028,6 +1095,9 @@ except Exception as e:
                     continuation.resume(throwing: LTXError.generationFailed(error.localizedDescription))
                 }
             }
+            }
+        } onCancel: {
+            holder.cancel()
         }
     }
 }

--- a/LTXVideoGenerator/Sources/Views/ContentView.swift
+++ b/LTXVideoGenerator/Sources/Views/ContentView.swift
@@ -16,6 +16,17 @@ struct ContentView: View {
     @State private var parameters: GenerationParameters = SessionSettings.loadParameters()
     @State private var showError = false
 
+    /// Keep the error alert small enough that the OK button stays on screen.
+    /// Generation failures can carry thousands of characters of Python traceback,
+    /// which previously pushed the button below the bottom of the display. The
+    /// full detail is always written to /tmp/ltx_generation.log.
+    static func boundedAlertMessage(_ message: String) -> String {
+        let limit = 500
+        guard message.count > limit else { return message }
+        let head = message.prefix(limit).trimmingCharacters(in: .whitespacesAndNewlines)
+        return head + "…\n\n(Message truncated — full details in /tmp/ltx_generation.log)"
+    }
+
     enum Tab: String, CaseIterable {
         case generate = "Generate"
         case history = "Video Archive"
@@ -42,7 +53,7 @@ struct ContentView: View {
                 generationService.clearError()
             }
         } message: { error in
-            Text(error.localizedDescription)
+            Text(Self.boundedAlertMessage(error.localizedDescription))
         }
         .onChange(of: generationService.error) { _, newError in
             showError = newError != nil

--- a/LTXVideoGenerator/Sources/Views/PromptInputView.swift
+++ b/LTXVideoGenerator/Sources/Views/PromptInputView.swift
@@ -105,6 +105,12 @@ struct PromptInputView: View {
     private var generationActionsDisabled: Bool {
         prompt.isEmpty || generationService.isProcessing || generationService.currentRequest != nil
     }
+
+    /// Enqueueing more clips is allowed even while one is generating — the queue
+    /// processes sequentially, so only an empty prompt should block it.
+    private var addToQueueDisabled: Bool {
+        prompt.isEmpty
+    }
     
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -623,7 +629,7 @@ struct PromptInputView: View {
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.large)
-                .disabled(generationActionsDisabled)
+                .disabled(addToQueueDisabled)
                 
                 // Batch button
                 Menu {
@@ -643,7 +649,7 @@ struct PromptInputView: View {
                 }
                 .menuStyle(.borderlessButton)
                 .frame(width: 44)
-                .disabled(generationActionsDisabled)
+                .disabled(addToQueueDisabled)
             }
 
             if !disableAudio && parameters.fps != 24 {


### PR DESCRIPTION
Three independent reliability fixes to generation control:

1. **Add to Queue stays usable while generating** — the button and batch menu were disabled whenever a generation was processing, so you couldn't stack up more clips. They now only require a non-empty prompt (the queue already runs sequentially).

2. **Cancelling actually kills the Python process** — previously cancel only marked the Swift Task cancelled; the subprocess kept running and held GPU/memory. The run is now wrapped in `withTaskCancellationHandler` with a thread-safe process holder, and the Python wrapper launches the `mlx_video` child with `start_new_session` and forwards SIGTERM as SIGKILL to the whole child process group so nothing is orphaned. User cancels resolve quietly (no error dialog).

3. **Error dialog can no longer push OK off-screen** — failure messages can carry thousands of characters of traceback, growing the alert past the bottom of the display. The message is now capped (~500 chars) with a pointer to `/tmp/ltx_generation.log`, which still holds full detail.

Independent of any library change; safe to merge on its own.