### PR TITLE
Add first/last frame and multi-image keyframe conditioning

### DIFF
--- a/LTXVideoGenerator/Resources/av_generator.py
+++ b/LTXVideoGenerator/Resources/av_generator.py
@@ -127,6 +127,26 @@ def main():
         help="Image conditioning strength (0.0-1.0)",
     )
     parser.add_argument(
+        "--image-frame-idx",
+        type=int,
+        default=0,
+        help=(
+            "Latent frame index to anchor the conditioning image "
+            "(0 = first frame; last frame = (num_frames - 1) // 8)"
+        ),
+    )
+    parser.add_argument(
+        "--keyframe",
+        action="append",
+        default=None,
+        metavar="PATH|FRAME_IDX|STRENGTH",
+        help=(
+            "Add a conditioning keyframe (repeatable). Format: "
+            "PATH|FRAME_IDX|STRENGTH (STRENGTH optional, default 1.0). "
+            "Takes precedence over --image for multi-image conditioning."
+        ),
+    )
+    parser.add_argument(
         "--tiling",
         type=str,
         default="auto",
@@ -150,12 +170,25 @@ def main():
 
     args = parser.parse_args()
 
+    # Parse repeatable --keyframe PATH|FRAME_IDX|STRENGTH specs into dicts.
+    keyframes = None
+    if args.keyframe:
+        keyframes = []
+        for spec in args.keyframe:
+            parts = spec.split("|")
+            path = parts[0]
+            frame_idx = int(parts[1]) if len(parts) > 1 and parts[1] != "" else 0
+            strength = float(parts[2]) if len(parts) > 2 and parts[2] != "" else 1.0
+            keyframes.append(
+                {"path": path, "frame_idx": frame_idx, "strength": strength}
+            )
+
     try:
         status_output("Loading unified audio-video model...")
 
         from mlx_video.generate_av import generate_video_with_audio
 
-        is_i2v = args.image is not None
+        is_i2v = args.image is not None or bool(keyframes)
         mode_str = "I2V" if is_i2v else "T2V"
         status_output(
             "Starting "
@@ -177,6 +210,8 @@ def main():
             cfg_scale=args.cfg_scale,
             image=args.image,
             image_strength=args.image_strength,
+            image_frame_idx=args.image_frame_idx,
+            keyframes=keyframes,
             tiling=args.tiling,
             num_inference_steps=args.num_inference_steps,
             verbose=True,

--- a/LTXVideoGenerator/Sources/Models/GenerationRequest.swift
+++ b/LTXVideoGenerator/Sources/Models/GenerationRequest.swift
@@ -292,6 +292,16 @@ enum GenerationStatus: String, Codable, Equatable {
     case cancelled
 }
 
+/// A single conditioning image pinned to a position along the video timeline.
+/// `position` is a fraction 0.0...1.0 (0 = first frame, 1 = last frame); the
+/// generation bridge maps it to a latent frame index based on `numFrames`.
+struct Keyframe: Codable, Equatable, Hashable, Identifiable {
+    var id: UUID = UUID()
+    var imagePath: String
+    var position: Double = 1.0
+    var strength: Double = 1.0
+}
+
 struct GenerationParameters: Codable, Equatable, Hashable {
     var numInferenceSteps: Int
     var guidanceScale: Double
@@ -302,7 +312,13 @@ struct GenerationParameters: Codable, Equatable, Hashable {
     var seed: Int?
     var vaeTilingMode: String
     var imageStrength: Double
-    
+    /// Which frame the source image anchors: "first" (default) or "last".
+    /// Only meaningful for image-to-video generation.
+    var imageFramePosition: String = "first"
+    /// Additional conditioning keyframes beyond the primary source image.
+    /// Each pins an image to a position along the timeline.
+    var keyframes: [Keyframe] = []
+
     // Default for LTX-2 on Apple Silicon
     static let `default` = GenerationParameters(
         numInferenceSteps: 30,
@@ -375,5 +391,25 @@ struct GenerationParameters: Codable, Equatable, Hashable {
         let baseVRAM = 20.0 + Double(numFrames) * 0.2
         let resolutionScale = Double(width * height) / (768.0 * 512.0)
         return Int(baseVRAM * resolutionScale)
+    }
+}
+
+extension GenerationParameters {
+    // Custom decoder so older saved presets/history/profiles (which predate
+    // `imageFramePosition`) still decode. Declared in an extension to preserve
+    // the synthesized memberwise initializer used throughout the app.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        numInferenceSteps = try c.decode(Int.self, forKey: .numInferenceSteps)
+        guidanceScale = try c.decode(Double.self, forKey: .guidanceScale)
+        width = try c.decode(Int.self, forKey: .width)
+        height = try c.decode(Int.self, forKey: .height)
+        numFrames = try c.decode(Int.self, forKey: .numFrames)
+        fps = try c.decode(Int.self, forKey: .fps)
+        seed = try c.decodeIfPresent(Int.self, forKey: .seed)
+        vaeTilingMode = try c.decode(String.self, forKey: .vaeTilingMode)
+        imageStrength = try c.decode(Double.self, forKey: .imageStrength)
+        imageFramePosition = try c.decodeIfPresent(String.self, forKey: .imageFramePosition) ?? "first"
+        keyframes = try c.decodeIfPresent([Keyframe].self, forKey: .keyframes) ?? []
     }
 }

--- a/LTXVideoGenerator/Sources/Services/LTXBridge.swift
+++ b/LTXVideoGenerator/Sources/Services/LTXBridge.swift
@@ -238,11 +238,30 @@ class LTXBridge {
             .replacingOccurrences(of: "\"", with: "\\\"")
             .replacingOccurrences(of: "\n", with: "\\n")
         
-        // Escape source image path if provided
-        let escapedImagePath = request.sourceImagePath?
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"") ?? ""
-        
+        // Build conditioning keyframes (primary source image + extra keyframes).
+        // Each is encoded as "path|latentFrameIdx|strength"; "|" never appears in
+        // macOS file paths so it is a safe delimiter for the library CLI.
+        let latentFrameCount = 1 + (params.numFrames - 1) / 8
+        let lastLatentIdx = max(0, latentFrameCount - 1)
+        func latentIndex(forFraction f: Double) -> Int {
+            let idx = Int((f * Double(lastLatentIdx)).rounded())
+            return min(max(idx, 0), lastLatentIdx)
+        }
+        func pyEscape(_ s: String) -> String {
+            s.replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "\"", with: "\\\"")
+        }
+        var keyframeSpecs: [String] = []
+        if let primary = request.sourceImagePath, !primary.isEmpty {
+            let idx = request.parameters.imageFramePosition == "last" ? lastLatentIdx : 0
+            keyframeSpecs.append("\(pyEscape(primary))|\(idx)|\(params.imageStrength)")
+        }
+        for kf in params.keyframes where !kf.imagePath.isEmpty {
+            let idx = latentIndex(forFraction: kf.position)
+            keyframeSpecs.append("\(pyEscape(kf.imagePath))|\(idx)|\(kf.strength)")
+        }
+        let keyframesPyList = "[" + keyframeSpecs.map { "\"\($0)\"" }.joined(separator: ", ") + "]"
+
         // Log file path
         let logFile = "/tmp/ltx_generation.log"
         
@@ -341,9 +360,9 @@ try:
                 "Preferences: enable 'Use local mlx-video-with-audio repo' or set LTX_FORCE_LOCAL_MLX_VIDEO=1 to override."
             )
 
-    # Image-to-video mode
-    source_image_path = "\(escapedImagePath)" if "\(escapedImagePath)" else None
-    mode = "image-to-video" if source_image_path else "text-to-video"
+    # Conditioning keyframes (primary source image + any extra keyframes)
+    keyframe_specs = \(keyframesPyList)
+    mode = "image-to-video" if keyframe_specs else "text-to-video"
     
     prompt = '''\(escapedPrompt)'''
     negative_prompt = '''\(escapedNegativePrompt)'''
@@ -376,11 +395,12 @@ try:
     else:
         log(f"Mode: {mode} (with audio)")
     
-    # Add image conditioning if provided
-    if source_image_path:
-        cmd.extend(["--image", source_image_path])
-        cmd.extend(["--image-strength", str(\(params.imageStrength))])
-        log(f"Image conditioning: {source_image_path}")
+    # Add conditioning keyframes if provided (path|latent_frame_idx|strength).
+    # latent_frame_idx is already computed app-side from each keyframe's timeline
+    # position and the frame count.
+    for spec in keyframe_specs:
+        cmd.extend(["--keyframe", spec])
+        log(f"Keyframe: {spec}")
     
     if (not disable_audio) and \(saveAudioTrackSeparately ? "True" : "False"):
         cmd.append("--save-audio-separately")

--- a/LTXVideoGenerator/Sources/Views/PromptInputView.swift
+++ b/LTXVideoGenerator/Sources/Views/PromptInputView.swift
@@ -300,13 +300,27 @@ struct PromptInputView: View {
                         .buttonStyle(.bordered)
                     }
                     
-                    Text("Select an image to use as the first frame. Your prompt should describe the motion/action.")
+                    Text("Select an image to anchor the first or last frame. Your prompt should describe the motion/action.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                     
                     if sourceImagePath != nil {
                         Divider()
-                        
+
+                        Picker("Use image as", selection: $parameters.imageFramePosition) {
+                            Text("First frame").tag("first")
+                            Text("Last frame").tag("last")
+                        }
+                        .pickerStyle(.segmented)
+
+                        Text(parameters.imageFramePosition == "last"
+                            ? "The image becomes the final frame. Your prompt should describe the motion/action leading up to it."
+                            : "The image becomes the first frame. Your prompt should describe the motion/action.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        Divider()
+
                         ParameterSlider(
                             title: "Image Strength",
                             value: $parameters.imageStrength,
@@ -315,9 +329,84 @@ struct PromptInputView: View {
                             icon: "photo.fill",
                             format: "%.2f"
                         )
-                        
-                        Text("How strongly the source image influences generation. 1.0 = exact first frame, lower = more creative freedom.")
+
+                        Text("How strongly the source image influences generation. 1.0 = exact match, lower = more creative freedom.")
                             .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Divider()
+
+                    HStack {
+                        Label("Additional Keyframes", systemImage: "rectangle.stack.badge.plus")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button {
+                            addKeyframe()
+                        } label: {
+                            Label("Add", systemImage: "plus")
+                                .font(.caption)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+
+                    if parameters.keyframes.isEmpty {
+                        Text("Pin extra images anywhere on the timeline (e.g. a mid-point pose). Each image is held at its position — keep them visually consistent or the motion will jump.")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach($parameters.keyframes) { $kf in
+                            VStack(alignment: .leading, spacing: 6) {
+                                HStack {
+                                    Image(systemName: "photo")
+                                        .foregroundStyle(.secondary)
+                                    Text(URL(fileURLWithPath: kf.imagePath).lastPathComponent)
+                                        .font(.caption)
+                                        .lineLimit(1)
+                                        .truncationMode(.middle)
+                                    Spacer()
+                                    Button(role: .destructive) {
+                                        parameters.keyframes.removeAll { $0.id == kf.id }
+                                    } label: {
+                                        Image(systemName: "xmark.circle.fill")
+                                    }
+                                    .buttonStyle(.plain)
+                                    .foregroundStyle(.red)
+                                }
+
+                                HStack {
+                                    Text("Position")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                        .frame(width: 58, alignment: .leading)
+                                    Slider(value: $kf.position, in: 0...1, step: 0.05)
+                                    Text("\(Int((kf.position * 100).rounded()))%")
+                                        .font(.caption2.monospacedDigit())
+                                        .frame(width: 42, alignment: .trailing)
+                                }
+
+                                HStack {
+                                    Text("Strength")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                        .frame(width: 58, alignment: .leading)
+                                    Slider(value: $kf.strength, in: 0...1, step: 0.05)
+                                    Text(String(format: "%.2f", kf.strength))
+                                        .font(.caption2.monospacedDigit())
+                                        .frame(width: 42, alignment: .trailing)
+                                }
+                            }
+                            .padding(8)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(Color(nsColor: .controlBackgroundColor))
+                            )
+                        }
+
+                        Text("Position: 0% = first frame, 100% = last frame. There are only ~\(max(1, 1 + (parameters.numFrames - 1) / 8)) distinct latent slots, so nearby positions may land on the same frame.")
+                            .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
                 }
@@ -828,8 +917,12 @@ struct PromptInputView: View {
     }
     
     private func generateBatch(count: Int) {
-        let requests = (0..<count).map { _ in
-            GenerationRequest(
+        let requests = (0..<count).map { _ -> GenerationRequest in
+            // Copy the full parameter set (preserving frame position, keyframes,
+            // tiling, etc.) and only randomize the seed per batch item.
+            var perItemParameters = parameters
+            perItemParameters.seed = Int.random(in: 0..<Int(Int32.max))
+            return GenerationRequest(
                 prompt: prompt,
                 negativePrompt: negativePrompt,
                 voiceoverText: voiceoverText,
@@ -843,17 +936,7 @@ struct PromptInputView: View {
                 gemmaTopP: gemmaTopP,
                 modelId: selectedModelID,
                 textEncoderId: selectedTextEncoderID,
-                parameters: GenerationParameters(
-                    numInferenceSteps: parameters.numInferenceSteps,
-                    guidanceScale: parameters.guidanceScale,
-                    width: parameters.width,
-                    height: parameters.height,
-                    numFrames: parameters.numFrames,
-                    fps: parameters.fps,
-                    seed: Int.random(in: 0..<Int(Int32.max)),
-                    vaeTilingMode: parameters.vaeTilingMode,
-                    imageStrength: parameters.imageStrength
-                )
+                parameters: perItemParameters
             )
         }
         generationService.addBatch(requests)
@@ -899,6 +982,25 @@ struct PromptInputView: View {
         }
     }
     
+    private func addKeyframe() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowedContentTypes = [.image, .png, .jpeg, .webP]
+        panel.message = "Select keyframe image(s) to pin along the timeline"
+        panel.prompt = "Add"
+
+        if panel.runModal() == .OK {
+            for url in panel.urls {
+                parameters.keyframes.append(
+                    Keyframe(imagePath: url.path, position: 1.0, strength: 1.0)
+                )
+            }
+            showImageToVideo = true
+        }
+    }
+
     private func loadThumbnail(from url: URL) {
         if let image = NSImage(contentsOf: url) {
             // Create a smaller thumbnail for display


### PR DESCRIPTION
Generalize image-to-video conditioning from a single source image to an arbitrary set of keyframes, each pinned to a point on the timeline.

- **First frame / Last frame** toggle for the primary source image.
- **Additional Keyframes** UI: add any number of extra images, each with a Position (0% = first … 100% = last) and Strength.
- `GenerationParameters` gains a `Keyframe` list + `imageFramePosition`, with backward-compatible decoding for older saved presets/profiles.
- The bridge routes all image conditioning through the library's repeatable `--keyframe PATH|FRAME_IDX|STRENGTH` flag, mapping each timeline position to a latent frame index (8× temporal compression). Batch generation preserves keyframes/position.

⚠️ **Depends on** the matching `mlx-video-with-audio` change that adds the `--keyframe` flag — it must be released/installed before image-to-video works with this build: https://github.com/james-see/mlx-video-with-audio/pull/2