### PR TITLE
Fix #75: pause/cleanup video player on view disappear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.3.65] - 2026-07-27
+
+### Fixed
+- **Issue #75 — Video archive playback stuck in endless loop** — When navigating away from the video archive while a video was still playing, the `AVPlayer` kept looping silently in the background with no UI indication and no way to stop it without force-quitting the app. The `NotificationCenter` observer for loop playback was never removed on view disappear. Now the observer is tracked, removed on `onDisappear`, and the player is paused and nilled out.
+
 ## [2.3.64] - 2026-07-27
 
 ### Fixed

--- a/LTXVideoGenerator/LTXVideoGenerator.xcodeproj/project.pbxproj
+++ b/LTXVideoGenerator/LTXVideoGenerator.xcodeproj/project.pbxproj
@@ -404,7 +404,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.3.64;
+				MARKETING_VERSION = 2.3.65;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ltxvideo.generator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -432,7 +432,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.3.64;
+				MARKETING_VERSION = 2.3.65;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jamescampbell.ltxvideogenerator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LTXVideoGenerator/Sources/Views/HistoryView.swift
+++ b/LTXVideoGenerator/Sources/Views/HistoryView.swift
@@ -303,6 +303,7 @@ struct HistoryDetailView: View {
     let result: GenerationResult
     let onAddAudio: (GenerationResult) -> Void
     @State private var player: AVPlayer?
+    @State private var endObserver: NSObjectProtocol?
     
     var body: some View {
         VStack(spacing: 0) {
@@ -442,13 +443,28 @@ struct HistoryDetailView: View {
         .onChange(of: result.id) { _, _ in
             loadPlayer()
         }
+        .onDisappear {
+            if let observer = endObserver {
+                NotificationCenter.default.removeObserver(observer)
+                endObserver = nil
+            }
+            player?.pause()
+            player = nil
+        }
     }
     
     private func loadPlayer() {
+        // Clean up previous observer/player if reloading
+        if let observer = endObserver {
+            NotificationCenter.default.removeObserver(observer)
+            endObserver = nil
+        }
+        player?.pause()
+        
         player = AVPlayer(url: result.videoURL)
         
         // Loop playback
-        NotificationCenter.default.addObserver(
+        endObserver = NotificationCenter.default.addObserver(
             forName: .AVPlayerItemDidPlayToEndTime,
             object: player?.currentItem,
             queue: .main


### PR DESCRIPTION
## Problem

When playing a generated video in the video archive, navigating away while the video is still playing causes the playback to loop endlessly in the background. There's no UI indication it's still playing and no way to stop it without force-quitting the app.

## Root Cause

 registered a  observer for  (for loop playback) but never removed it. When the view disappeared, the player kept playing and looping silently.

## Fix

- Track the notification observer in an  state variable
- Add  that removes the observer, pauses the player, and nils it out
- Clean up any previous observer in  before creating a new one (handles switching between videos)

## Testing

- Build verified:  (Debug, no code signing)
- Runtime behavior requires manual testing in the running app

Closes #75