### PR TITLE
Add higher resolution options + warning (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.3.66] - 2026-07-27
+
+### Added
+- **Issue #68 — Additional resolution options** — Added wider resolution options to the width picker (1280, 1536, 1920, 2048) and height picker (704, 864, 1080, 1152). A warning is shown when selecting resolutions above the 768×512 training size, noting increased generation time, higher memory usage, potential OOM errors, and that quality may not improve beyond the model's native resolution.
+
 ## [2.3.65] - 2026-07-27
 
 ### Fixed

--- a/LTXVideoGenerator/LTXVideoGenerator.xcodeproj/project.pbxproj
+++ b/LTXVideoGenerator/LTXVideoGenerator.xcodeproj/project.pbxproj
@@ -404,7 +404,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.3.65;
+				MARKETING_VERSION = 2.3.66;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ltxvideo.generator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -432,7 +432,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.3.65;
+				MARKETING_VERSION = 2.3.66;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jamescampbell.ltxvideogenerator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LTXVideoGenerator/Sources/Views/ParametersView.swift
+++ b/LTXVideoGenerator/Sources/Views/ParametersView.swift
@@ -136,11 +136,15 @@ struct ParametersView: View {
                                     Text("768").tag(768)
                                     Text("896").tag(896)
                                     Text("1024").tag(1024)
+                                    Text("1280").tag(1280)
+                                    Text("1536").tag(1536)
+                                    Text("1920").tag(1920)
+                                    Text("2048").tag(2048)
                                 }
                                 .labelsHidden()
                                 .frame(width: 80)
                             }
-                            
+
                             VStack(alignment: .leading) {
                                 Text("Height")
                                     .font(.caption)
@@ -150,7 +154,11 @@ struct ParametersView: View {
                                     Text("384").tag(384)
                                     Text("512").tag(512)
                                     Text("576").tag(576)
+                                    Text("704").tag(704)
                                     Text("768").tag(768)
+                                    Text("864").tag(864)
+                                    Text("1080").tag(1080)
+                                    Text("1152").tag(1152)
                                 }
                                 .labelsHidden()
                                 .frame(width: 80)
@@ -167,6 +175,17 @@ struct ParametersView: View {
                                     RoundedRectangle(cornerRadius: 6)
                                         .fill(Color(nsColor: .controlBackgroundColor))
                                 )
+                        }
+
+                        if parameters.width * parameters.height > 768 * 512 {
+                            HStack(alignment: .top, spacing: 6) {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .foregroundStyle(.orange)
+                                Text("Higher resolutions significantly increase generation time and memory usage. LTX-2 models are trained at 768×512; larger outputs may not improve quality and can cause Metal OOM errors. Reduce frame count or use aggressive VAE tiling if you hit memory limits.")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+                            .padding(.top, 4)
                         }
                     }
                     


### PR DESCRIPTION
## Changes

Adds wider resolution options to the width and height pickers in ParametersView:

**Width:** 1280, 1536, 1920, 2048 (in addition to existing 320–1024)
**Height:** 704, 864, 1080, 1152 (in addition to existing 320–768)

This enables the resolutions requested in #68: 2048x1152, 1536x864, 1280x704, 1920x1080.

### Warning

When resolution exceeds the model's native 768x512 training size, an orange warning is shown:
- Higher resolutions significantly increase generation time and memory usage
- LTX-2 models are trained at 768x512; larger outputs may not improve quality
- Can cause Metal OOM errors
- Recommends reducing frame count or using aggressive VAE tiling

### Why no hard cap

The VRAM estimation and OOM recovery hints already scale with resolution. Users on high-memory Macs (64GB+) can legitimately use higher resolutions. The warning gives them the information to make that call.

Closes #68