### PR TITLE
feat: add configurable model cache directory

### DIFF
--- a/LTXVideoGenerator/Sources/PythonEnvironment.swift
+++ b/LTXVideoGenerator/Sources/PythonEnvironment.swift
@@ -1,5 +1,60 @@
 import Foundation
 
+enum HuggingFaceCacheConfiguration {
+    static let directoryKey = "huggingFaceCacheDirectory"
+
+    static func configuredDirectory(userDefaults: UserDefaults = .standard) -> String? {
+        guard let rawPath = userDefaults.string(forKey: directoryKey)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !rawPath.isEmpty
+        else {
+            return nil
+        }
+
+        return NSString(string: rawPath).expandingTildeInPath
+    }
+
+    static func effectiveDirectory(userDefaults: UserDefaults = .standard) -> String {
+        configuredDirectory(userDefaults: userDefaults)
+            ?? FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".cache/huggingface", isDirectory: true)
+                .path
+    }
+
+    static func apply(
+        to environment: inout [String: String],
+        userDefaults: UserDefaults = .standard
+    ) {
+        guard let directory = configuredDirectory(userDefaults: userDefaults) else {
+            return
+        }
+
+        environment["HF_HOME"] = directory
+        environment["HF_HUB_CACHE"] = URL(fileURLWithPath: directory, isDirectory: true)
+            .appendingPathComponent("hub", isDirectory: true)
+            .path
+    }
+
+    static func availabilityError(userDefaults: UserDefaults = .standard) -> String? {
+        guard let directory = configuredDirectory(userDefaults: userDefaults) else {
+            return nil
+        }
+
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: directory, isDirectory: &isDirectory),
+              isDirectory.boolValue
+        else {
+            return "Configured model cache is unavailable: \(directory). Mount the external drive or choose another folder in Preferences → General → Storage."
+        }
+
+        guard FileManager.default.isWritableFile(atPath: directory) else {
+            return "Configured model cache is not writable: \(directory). Choose a writable folder in Preferences → General → Storage."
+        }
+
+        return nil
+    }
+}
+
 /// Details about a validated Python installation
 struct PythonDetails {
     let version: String

--- a/LTXVideoGenerator/Sources/Services/AudioService.swift
+++ b/LTXVideoGenerator/Sources/Services/AudioService.swift
@@ -1096,6 +1096,10 @@ class AudioService: ObservableObject {
         timeout: TimeInterval,
         stderrHandler: ((String) -> Void)? = nil
     ) async throws -> String {
+        if let cacheError = HuggingFaceCacheConfiguration.availabilityError() {
+            throw AudioError.mlxAudioFailed(cacheError)
+        }
+
         return try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
                 let process = Process()
@@ -1108,6 +1112,7 @@ class AudioService: ObservableObject {
                 env["HOME"] = ProcessInfo.processInfo.environment["HOME"] ?? ""
                 env["USER"] = ProcessInfo.processInfo.environment["USER"] ?? ""
                 env["TMPDIR"] = ProcessInfo.processInfo.environment["TMPDIR"] ?? "/tmp"
+                HuggingFaceCacheConfiguration.apply(to: &env)
                 process.environment = env
                 
                 let stdoutPipe = Pipe()

--- a/LTXVideoGenerator/Sources/Services/LTXBridge.swift
+++ b/LTXVideoGenerator/Sources/Services/LTXBridge.swift
@@ -848,7 +848,11 @@ except Exception as e:
         arguments: [String],
         timeout: TimeInterval = 60
     ) async throws -> String {
-        try await withCheckedThrowingContinuation { continuation in
+        if let cacheError = HuggingFaceCacheConfiguration.availabilityError() {
+            throw LTXError.generationFailed(cacheError)
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
                 let process = Process()
                 process.executableURL = URL(fileURLWithPath: executable)
@@ -859,6 +863,7 @@ except Exception as e:
                 env["HOME"] = ProcessInfo.processInfo.environment["HOME"] ?? ""
                 env["USER"] = ProcessInfo.processInfo.environment["USER"] ?? ""
                 env["TMPDIR"] = ProcessInfo.processInfo.environment["TMPDIR"] ?? "/tmp"
+                HuggingFaceCacheConfiguration.apply(to: &env)
                 process.environment = env
                 let stdoutPipe = Pipe()
                 let stderrPipe = Pipe()
@@ -894,6 +899,10 @@ except Exception as e:
         guard let python = pythonExecutable else {
             throw LTXError.pythonNotConfigured
         }
+
+        if let cacheError = HuggingFaceCacheConfiguration.availabilityError() {
+            throw LTXError.generationFailed(cacheError)
+        }
         
         let logFile = "/tmp/ltx_generation.log"
         
@@ -911,6 +920,7 @@ except Exception as e:
                 env["HOME"] = ProcessInfo.processInfo.environment["HOME"] ?? ""
                 env["USER"] = ProcessInfo.processInfo.environment["USER"] ?? ""
                 env["TMPDIR"] = ProcessInfo.processInfo.environment["TMPDIR"] ?? "/tmp"
+                HuggingFaceCacheConfiguration.apply(to: &env)
                 
                 // MLX uses Metal - inherit any Metal-related env vars
                 if let metalDevice = ProcessInfo.processInfo.environment["MTL_DEVICE_WRAPPER_TYPE"] {

--- a/LTXVideoGenerator/Sources/Views/PreferencesView.swift
+++ b/LTXVideoGenerator/Sources/Views/PreferencesView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct PreferencesView: View {
     @AppStorage("pythonPath") private var pythonPath = ""
     @AppStorage("outputDirectory") private var outputDirectory = ""
+    @AppStorage(HuggingFaceCacheConfiguration.directoryKey) private var huggingFaceCacheDirectory = ""
     @AppStorage("autoLoadModel") private var autoLoadModel = false
     @AppStorage("keepCompletedInQueue") private var keepCompletedInQueue = false
     @AppStorage("elevenLabsApiKey") private var elevenLabsApiKey = ""
@@ -33,6 +34,21 @@ struct PreferencesView: View {
 
     private var selectedTextEncoder: LTXTextEncoder {
         LTXTextEncoderCatalog.resolvedTextEncoder(id: selectedTextEncoderID)
+    }
+
+    private var modelCachePath: String {
+        HuggingFaceCacheConfiguration.effectiveDirectory()
+    }
+
+    private var modelCacheDescription: String {
+        let path = huggingFaceCacheDirectory.isEmpty ? "~/.cache/huggingface" : modelCachePath
+        return "\(path)/hub"
+    }
+
+    private var modelCacheExists: Bool {
+        var isDirectory: ObjCBool = false
+        return FileManager.default.fileExists(atPath: modelCachePath, isDirectory: &isDirectory)
+            && isDirectory.boolValue
     }
 
     private var appVersionText: String {
@@ -240,7 +256,7 @@ struct PreferencesView: View {
                         VStack(alignment: .leading, spacing: 4) {
                             Text(selectedModel.displayName)
                                 .font(.caption.bold())
-                            Text("Uses \(selectedModel.repo) (\(selectedModel.downloadSize) download). Model cached in ~/.cache/huggingface/")
+                            Text("Uses \(selectedModel.repo) (\(selectedModel.downloadSize) download). Model cache: \(modelCacheDescription)")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
@@ -324,6 +340,33 @@ struct PreferencesView: View {
                     Text("Leave empty to use default location in Application Support")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+
+                    HStack {
+                        TextField("Model Cache Directory", text: $huggingFaceCacheDirectory)
+                            .textFieldStyle(.roundedBorder)
+
+                        Button("Browse...") {
+                            selectModelCacheDirectory()
+                        }
+
+                        Button("Open") {
+                            openModelCacheDirectory()
+                        }
+                        .disabled(!modelCacheExists)
+                    }
+
+                    HStack {
+                        Text("Leave empty to use ~/.cache/huggingface. Choose a mounted external-drive folder to store downloaded models. Existing cache files are not moved automatically.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        if !huggingFaceCacheDirectory.isEmpty {
+                            Button("Use Default") {
+                                huggingFaceCacheDirectory = ""
+                            }
+                            .controlSize(.small)
+                        }
+                    }
                 }
 
                 Section("Reset") {
@@ -539,7 +582,29 @@ struct PreferencesView: View {
             outputDirectory = url.path
         }
     }
-    
+
+    private func selectModelCacheDirectory() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = true
+        panel.message = "Select a folder for Hugging Face model downloads"
+        panel.prompt = "Select"
+
+        if modelCacheExists {
+            panel.directoryURL = URL(fileURLWithPath: modelCachePath, isDirectory: true)
+        }
+
+        if panel.runModal() == .OK, let url = panel.url {
+            huggingFaceCacheDirectory = url.path
+        }
+    }
+
+    private func openModelCacheDirectory() {
+        NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: modelCachePath)
+    }
+
     private func openOutputDirectory() {
         let path = outputDirectory.isEmpty
             ? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The `mlx-video-with-audio` package is available on [PyPI](https://pypi.org/proje
 
 **Important:** On first generation, the app downloads your selected model from Hugging Face. This is a one-time download that may take 15-30 minutes depending on model size and internet connection.
 
-The model is cached in `~/.cache/huggingface/` and will not be re-downloaded on subsequent runs.
+The model is cached in `~/.cache/huggingface/` by default and will not be re-downloaded on subsequent runs. To keep large model files on another disk, choose a **Model Cache Directory** under **Settings > General > Storage** before the first generation.
 
 Progress is shown in the app during download.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -96,6 +96,16 @@ Models are cached by Hugging Face in folders such as:
 ~/.cache/huggingface/hub/models--dgrauet--ltx-2.3-mlx-distilled-q4/
 ```
 
+To store new downloads on another disk:
+
+1. Open **Preferences > General > Storage**
+2. Set **Model Cache Directory** to a folder on the mounted disk
+3. Start generation after confirming the disk is still mounted
+
+The app passes the selected directory to Hugging Face through `HF_HOME` and stores Hub downloads in its `hub` subfolder. Existing cache files are not moved automatically. Copy them from `~/.cache/huggingface/` into the selected directory before removing the originals.
+
+If the selected folder is unavailable or not writable, generation stops with an error instead of silently downloading models to the internal disk.
+
 To free up space later, you can delete this folder (the model will re-download on next use).
 
 ## Optional: Gemma Prompt Enhancement


### PR DESCRIPTION
## Summary

- add a **Model Cache Directory** picker under Settings → General → Storage
- pass the selected path to video, prompt-enhancement, and MLX Audio subprocesses through `HF_HOME` and `HF_HUB_CACHE`
- stop with a clear error when the configured external folder is unavailable or not writable
- document external-drive setup and existing-cache migration

Addresses the use case reported in [discussion #79](https://github.com/james-see/ltx-video-mac/discussions/79).

## Validation

- `xcodebuild -project LTXVideoGenerator/LTXVideoGenerator.xcodeproj -scheme LTXVideoGenerator -configuration Debug CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project LTXVideoGenerator/LTXVideoGenerator.xcodeproj -scheme LTXVideoGenerator -configuration Release CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`

Both Xcode builds pass. `swift build` is currently blocked by the pre-existing `Package.swift` reference to PythonKit's removed `master` branch; the Xcode project already uses `main`.
