### PR TITLE
Add image-to-video support to REST API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- **REST API image-to-video** — `POST /generate` now accepts an optional absolute `source_image_path`, validates that it is a readable image, and forwards it to the existing image-to-video generation pipeline. `parameters.image_strength` and `parameters.vae_tiling_mode` are also accepted.
+- Queue and submission responses now identify `text-to-video` versus `image-to-video` jobs and return the source image filename.
+
+### Security
+- Bind the local REST API to `127.0.0.1` because image-to-video requests can reference files on the Mac.
+
 ## [2.3.66] - 2026-07-27
 
 ### Added

--- a/LTXVideoGenerator/Sources/Services/APIServer.swift
+++ b/LTXVideoGenerator/Sources/Services/APIServer.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Network
+import UniformTypeIdentifiers
 
 @MainActor
 class APIServer: ObservableObject {
@@ -21,8 +22,11 @@ class APIServer: ObservableObject {
         do {
             let params = NWParameters.tcp
             params.allowLocalEndpointReuse = true
-            
-            listener = try NWListener(using: params, on: NWEndpoint.Port(rawValue: port)!)
+            let endpointPort = NWEndpoint.Port(rawValue: port)!
+            params.requiredLocalEndpoint = .hostPort(host: "127.0.0.1", port: endpointPort)
+
+            // The API accepts local file paths, so it must not be exposed to the LAN.
+            listener = try NWListener(using: params)
             
             listener?.stateUpdateHandler = { [weak self] state in
                 Task { @MainActor in
@@ -118,11 +122,11 @@ class APIServer: ObservableObject {
         case ("GET", "/"):
             sendResponse(connection, status: 200, body: [
                 "service": "LTX Video Generator",
-                "version": "1.0.5",
+                "version": Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown",
                 "endpoints": [
                     "GET /status": "Server and generation status",
                     "GET /queue": "Current generation queue",
-                    "POST /generate": "Submit generation request (optional model_id, text_encoder_id)",
+                    "POST /generate": "Submit generation request (optional source_image_path, model_id, text_encoder_id)",
                     "DELETE /queue/:id": "Cancel a queued request"
                 ]
             ])
@@ -143,6 +147,8 @@ class APIServer: ObservableObject {
                 return [
                     "id": request.id.uuidString,
                     "prompt": request.prompt,
+                    "mode": request.isImageToVideo ? "image-to-video" : "text-to-video",
+                    "source_image_name": request.sourceImagePath.map { URL(fileURLWithPath: $0).lastPathComponent } ?? NSNull(),
                     "status": request.status.rawValue,
                     "created_at": ISO8601DateFormatter().string(from: request.createdAt),
                     "model": [
@@ -175,6 +181,11 @@ class APIServer: ObservableObject {
             }
             
             let negativePrompt = body["negative_prompt"] as? String ?? ""
+            let sourceImageValidation = validateSourceImagePath(body["source_image_path"])
+            if let validationError = sourceImageValidation.error {
+                sendResponse(connection, status: 400, body: ["error": validationError])
+                return
+            }
             let voiceoverText = body["voiceover_text"] as? String ?? ""
             let voiceoverSource = body["voiceover_source"] as? String ?? "mlx-audio"
             let voiceoverVoice = body["voiceover_voice"] as? String ?? "af_heart"
@@ -210,6 +221,14 @@ class APIServer: ObservableObject {
                 if let steps = p["num_inference_steps"] as? Int { params.numInferenceSteps = steps }
                 if let guidance = p["guidance_scale"] as? Double { params.guidanceScale = guidance }
                 if let seed = p["seed"] as? Int { params.seed = seed }
+                if let vaeTilingMode = p["vae_tiling_mode"] as? String { params.vaeTilingMode = vaeTilingMode }
+                if let imageStrength = p["image_strength"] as? Double {
+                    guard (0.0...1.0).contains(imageStrength) else {
+                        sendResponse(connection, status: 400, body: ["error": "parameters.image_strength must be between 0.0 and 1.0"])
+                        return
+                    }
+                    params.imageStrength = imageStrength
+                }
             }
             
             let request = GenerationRequest(
@@ -218,6 +237,7 @@ class APIServer: ObservableObject {
                 voiceoverText: voiceoverText,
                 voiceoverSource: voiceoverSource,
                 voiceoverVoice: voiceoverVoice,
+                sourceImagePath: sourceImageValidation.path,
                 musicEnabled: musicEnabled,
                 musicGenre: musicGenre,
                 modelId: resolvedModel.id,
@@ -229,6 +249,8 @@ class APIServer: ObservableObject {
             sendResponse(connection, status: 201, body: [
                 "id": request.id.uuidString,
                 "status": "queued",
+                "mode": request.isImageToVideo ? "image-to-video" : "text-to-video",
+                "source_image_name": request.sourceImagePath.map { URL(fileURLWithPath: $0).lastPathComponent } ?? NSNull(),
                 "model_id": request.modelId,
                 "model_repo": resolvedModel.repo,
                 "text_encoder_id": request.textEncoderId,
@@ -253,6 +275,39 @@ class APIServer: ObservableObject {
         default:
             sendResponse(connection, status: 404, body: ["error": "Not found"])
         }
+    }
+
+    /// Resolves and validates an optional local image path before it reaches the Python bridge.
+    private func validateSourceImagePath(_ value: Any?) -> (path: String?, error: String?) {
+        guard let value else { return (nil, nil) }
+        guard let rawPath = value as? String else {
+            return (nil, "source_image_path must be a string")
+        }
+
+        let trimmedPath = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPath.isEmpty else { return (nil, nil) }
+
+        let expandedPath = NSString(string: trimmedPath).expandingTildeInPath
+        guard expandedPath.hasPrefix("/") else {
+            return (nil, "source_image_path must be an absolute path")
+        }
+
+        let imageURL = URL(fileURLWithPath: expandedPath)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: imageURL.path, isDirectory: &isDirectory),
+              !isDirectory.boolValue,
+              FileManager.default.isReadableFile(atPath: imageURL.path) else {
+            return (nil, "source_image_path does not point to a readable file")
+        }
+
+        guard let fileType = UTType(filenameExtension: imageURL.pathExtension),
+              fileType.conforms(to: .image) else {
+            return (nil, "source_image_path must point to a supported image file")
+        }
+
+        return (imageURL.path, nil)
     }
     
     private func sendResponse(_ connection: NWConnection, status: Int, body: [String: Any]) {

--- a/README.md
+++ b/README.md
@@ -81,6 +81,33 @@ Progress is shown in the app during download.
 4. Watch progress in the Queue sidebar
 5. Find completed videos in your configured output directory (default: Application Support)
 
+### Local REST API
+
+Enable **API Server** in the app sidebar. The server listens only on `127.0.0.1:8420`.
+
+Image-to-video requests use an absolute path to a readable local image:
+
+```bash
+curl -X POST http://127.0.0.1:8420/generate \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "prompt": "The camera slowly pushes forward as banners move in the wind",
+    "source_image_path": "/absolute/path/to/source.png",
+    "model_id": "ltx23_unified",
+    "parameters": {
+      "width": 1536,
+      "height": 576,
+      "num_frames": 125,
+      "fps": 24,
+      "num_inference_steps": 30,
+      "guidance_scale": 3.0,
+      "image_strength": 1.0
+    }
+  }'
+```
+
+Omit `source_image_path` for text-to-video generation. The source image path is resolved and validated before the request is queued.
+
 ### Gemma Prompt Enhancement
 
 When enabled in **Settings > Generation**, Gemma rewrites your prompt before generation—expanding short descriptions into detailed, LTX-2–optimized prompts with visuals, audio, camera movement, and style. Use the **Preview enhanced prompt** button to see the rewritten prompt before generating.


### PR DESCRIPTION
## Summary

- accept an optional `source_image_path` in `POST /generate`
- normalize symlinks and validate that the path is absolute, readable, and an image
- forward the validated path to the existing image-to-video generation pipeline
- expose `parameters.image_strength` and `parameters.vae_tiling_mode` through the API
- identify text-to-video versus image-to-video jobs in submission and queue responses
- bind the file-path-capable API to `127.0.0.1` instead of all network interfaces
- document a complete image-to-video `curl` request

Omitting `source_image_path` preserves the existing text-to-video behavior.

## Testing

- Release build for Apple Silicon/macOS succeeded with code signing disabled
- submitted 21 local image-to-video API jobs using seven PNG source images and three seeds each; all requests were accepted and processing started
- `git diff --check` passes
