### PR TITLE
LTX-2.5 keyframe forwarding + DurationHead fix (2.3.83)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,155 @@
 # Agent notes — ltx-video-mac
 
-Native SwiftUI macOS app. Generation is a Python subprocess (`mlx-video-with-audio` on MLX). You are talking to a 20+ year full-stack owner: be concise, no tutorial filler.
+Native SwiftUI macOS app (14+). Generation is a local subprocess — not in-process MLX. You are talking to a 20+ year full-stack owner: be concise, no tutorial filler.
+
+Three backends via `GenerationBackend` on `LTXModel`:
+
+| Backend | When | Process |
+|---|---|---|
+| `mlxVideoWithAudio` | LTX-2 / 2.3 `notapalindrome` packs | `python -m mlx_video.generate_av` |
+| `ltx2Mlx` | LTX-2.5 + LTX-2.3 12GB | `ltx-2-mlx generate` (or adapter wrapper) |
+| `h3c` | MiniMax H3 | native `./h3` (C/Metal) |
 
 ## Repos
 
-| Repo | Path | Role |
+| Repo | Typical path | Role |
 |---|---|---|
-| This app | `/Users/jc/projects/ltx-video-mac` | SwiftUI shell, queue, UI, local REST API |
-| Library | `/Users/jc/projects/mlx-video-with-audio` | Actual I2V/T2V + audio. Owner: same person |
+| This app | `/Users/jc/p/ltx-video-mac` (or clone anywhere) | SwiftUI shell, queue, UI, local REST API |
+| Library | `/Users/jc/p/mlx-video-with-audio` | LTX-2 / 2.3 I2V/T2V + audio (PyPI `mlx-video-with-audio`) |
+| LTX-2.5 runtime | `~/projects/ltx-2-mlx` (Preferences local toggle) | `dgrauet/ltx-2-mlx` — do **not** port 2.5 into mlx-video-with-audio |
+| H3 engine | `~/projects/h3.c` or App Support clone | `antirez/h3.c` (BF16/Turbo); int8 fork for `minimax_h3_int8` |
 
-`LTXBridge` prefers pip unless `~/projects/mlx-video-with-audio` is newer, Preferences “Use local mlx-video-with-audio repo” is on, or `LTX_FORCE_LOCAL_MLX_VIDEO=1`.
+**Preference hardcodes:** local overrides look at `~/projects/mlx-video-with-audio` and `~/projects/ltx-2-mlx` regardless of where this git checkout lives. Symlink or clone there when using the toggles.
+
+`LTXBridge` prefers pip `mlx-video-with-audio` unless `~/projects/mlx-video-with-audio` is newer, Preferences “Use local mlx-video-with-audio repo” is on, or `LTX_FORCE_LOCAL_MLX_VIDEO=1`.
 
 If a PR changes the Python CLI (`--keyframe`, kwargs on `generate_video_with_audio`, etc.), land and **publish the library first**. Shipping the app against an unreleased flag breaks I2V for everyone on PyPI.
+
+## LTX-2.5 reference
+
+Upstream: [Lightricks/LTX-2.5](https://huggingface.co/Lightricks/LTX-2.5) (CUDA `ltx-pipelines` / Diffusers / Comfy). Mac path: MLX conversion [mlx-community/ltx-2.5-mlx](https://huggingface.co/mlx-community/ltx-2.5-mlx) + runtime [dgrauet/ltx-2-mlx](https://github.com/dgrauet/ltx-2-mlx) `@v0.15.2`. Plan: `plans/ltx-2.5-support.md`.
+
+### Catalog ↔ official model family
+
+| App `model_id` | Pack | CLI shape | Maps to official |
+|---|---|---|---|
+| `ltx25_distilled` | `mlx-community/ltx-2.5-mlx` (~100GB) | `--distilled` | Distilled DiT, fixed **8 steps, CFG=1** |
+| `ltx25_dev` | same + overlay LoRA ~8.3GB | `--two-stage` + `transformer-dev` + fuse `ltx-2.5-22b-distilled-lora-450-bf16` | Dev two-stage (half-res + spatial upscale + distilled-LoRA refine); stage-1 steps/CFG from UI (defaults 30 / 3), stage-2 = 3 |
+| `ltx25_distilled_ditq8` | same + `mlx-community/ltx-2.5-mlx-ditq8` overlay | `--distilled` on shadowed pack | Distilled + Q8 DiT (0.15.2 has no `--dit`) |
+
+Gemma 4 is **bundled** in `gemma4-12b-ltx-v1/`. Do not use the Gemma 3 picker for 2.5. `mlx-community/ltx-2.5-mlx-q8` is the **text encoder**, not a DiT quant — never catalog it as DiT.
+
+App loads the community pack through bundled `LTXVideoGenerator/Resources/ltx25_community_adapter.py` (patches Gemma 4 path + mixed-precision quant + DurationHead skip). Keep that file in the Xcode Resources target.
+
+### Implemented vs official “what's new”
+
+| Official feature | Status here |
+|---|---|
+| Distilled 8-step / CFG=1 | Yes |
+| Dev + distilled LoRA two-stage | Yes (`ltx25_dev`; LoRA from `dgrauet/ltx-2.5-mlx` or `Lightricks/LTX-2.5` `loras/`) |
+| Gemma 4 12B TE | Yes (pack + adapter) |
+| Prompt enhancer | Yes → `--enhance-prompt` (not Gemma 3 preview path) |
+| Audio VAE + vocoder | Yes (in pack) |
+| DiffVAE + spatial/temporal upscalers | In pack; two-stage uses spatial upscaler |
+| I2V first-frame | Yes → `--image` |
+| `num_frames % 8 == 1`; W/H ÷32 | Defaults OK; app snaps W/H to **64** (stricter) |
+| Extra timeline keyframes | Yes — repeatable `--image PATH FRAME_IDX STRENGTH` (pixel idx; mlx-video uses latent `--keyframe`) |
+| Duration predictor (omit frames) | Load fixed in adapter for community split q/k/v; app still passes `-f` from slider ([upstream #125](https://github.com/dgrauet/ltx-2-mlx/issues/125)) |
+| Native multishot / DFR | **Not wired** — no CLI in 0.15.2 ([upstream #127](https://github.com/dgrauet/ltx-2-mlx/issues/127)). `--segment` Prompt Relay not in UI yet |
+| Disable audio | **Ignored** on 0.15.2 ([upstream #126](https://github.com/dgrauet/ltx-2-mlx/issues/126)) |
+
+Parity epic: https://github.com/james-see/ltx-video-mac/issues/85
+
+Do **not** port 2.5 into `mlx-video-with-audio`. Pin install: `Ltx2MlxInstall` in `PythonEnvironment.swift` (`v0.15.2` core + pipelines) + `mlx-lm>=0.31.2`. Only required when a 2.5 / 12GB model is selected.
+
+## Dev / build
+
+### Day-to-day (Swift)
+
+```bash
+cd /Users/jc/p/ltx-video-mac   # or your clone
+open LTXVideoGenerator/LTXVideoGenerator.xcodeproj
+# Scheme: LTXVideoGenerator · Debug · My Mac (Apple Silicon)
+```
+
+Xcode project is the source of truth for shipping (Resources, signing). `LTXVideoGenerator/Package.swift` exists for SPM/PythonKit experiments — do not assume SPM alone ships the app bundle (`ltx25_community_adapter.py`, icons, etc.).
+
+Before push of compile-affecting changes: build succeeds in Xcode or:
+
+```bash
+xcodebuild -project LTXVideoGenerator/LTXVideoGenerator.xcodeproj \
+  -scheme LTXVideoGenerator -configuration Debug build
+```
+
+### Local signed / notarized DMG
+
+```bash
+./scripts/build-local.sh          # archive + Developer ID + notarytool + DMG → build/
+./scripts/build-release.sh        # CI-oriented (used by .github/workflows/release.yml)
+./scripts/setup-secrets.sh        # notarytool keychain profile (once)
+```
+
+### Python env the app uses
+
+Point Preferences at a venv (or Auto Detect). Install base deps:
+
+```bash
+pip install -r LTXVideoGenerator/requirements.txt
+```
+
+LTX-2.5 / 12GB (opt-in; app can auto-install on model select):
+
+```bash
+pip install \
+  "git+https://github.com/dgrauet/ltx-2-mlx.git@v0.15.2#subdirectory=packages/ltx-core-mlx" \
+  "git+https://github.com/dgrauet/ltx-2-mlx.git@v0.15.2#subdirectory=packages/ltx-pipelines-mlx" \
+  "mlx-lm>=0.31.2"
+```
+
+Or: clone `dgrauet/ltx-2-mlx` → `~/projects/ltx-2-mlx`, `uv sync --all-extras`, enable **Use local ltx-2-mlx repo**.
+
+Library local: clone → `~/projects/mlx-video-with-audio` (or symlink from `/Users/jc/p/mlx-video-with-audio`), enable **Use local mlx-video-with-audio repo** when iterating CLI flags.
+
+H3: Xcode CLT + first Generate clones/builds `h3`, or set **h3 binary path** / **H3 model directory**. Gated HF weights need `hf auth login`.
+
+### Layout agents touch most
+
+| Path | Notes |
+|---|---|
+| `LTXVideoGenerator/Sources/Services/LTXBridge.swift` | Backend dispatch, embedded Python scripts |
+| `LTXVideoGenerator/Sources/PythonEnvironment.swift` | Pins, validate, optional git installs |
+| `LTXVideoGenerator/Sources/Models/GenerationRequest.swift` | Catalog (`LTXModel`, backends) |
+| `LTXVideoGenerator/Resources/ltx25_community_adapter.py` | Must stay in app Resources |
+| `LTXVideoGenerator/requirements.txt` | Pip pins (keep in sync with `mlxVideoMinVersion`) |
+
+Python: format with `black`. New Swift files → add to the Xcode target or release archives omit them.
+
+## Dependencies
+
+### Host
+
+- macOS 14+, Apple Silicon
+- Xcode (dev) / Xcode CLT (H3 `make`)
+- Python **3.10+** (Preferences path; prefer 3.12 Homebrew/pyenv)
+- Optional: `uv` for local `ltx-2-mlx`
+
+### Pip (always — `requirements.txt`)
+
+`mlx`, `mlx-vlm`, `mlx-lm>=0.31.2`, `mlx-video-with-audio>=0.1.37`, `transformers`, `safetensors`, `huggingface_hub`, `numpy`, `Pillow`, `opencv-python`, `tqdm`, `mlx-audio`
+
+Pin source of truth: `mlxVideoMinVersion` in `PythonEnvironment.swift` **and** `requirements.txt`.
+
+### Opt-in
+
+| Need | Dep |
+|---|---|
+| LTX-2.5 / 12GB | `ltx-core-mlx` + `ltx-pipelines-mlx` @ `v0.15.2` (git; not PyPI) |
+| MiniMax H3 | local `h3` binary + HF weights (~92–144GB) |
+| Voiceover / music | ElevenLabs keys and/or `mlx-audio` |
+
+### Weights (HF cache via `HuggingFaceCacheConfiguration`)
+
+Default `~/.cache/huggingface/`; override with Preferences Model Cache Directory (`HF_HOME` + `HF_HUB_CACHE` on every download Process). Fail closed if configured folder missing/unwritable.
 
 ## Library release (mlx-video-with-audio)
 
@@ -26,7 +164,7 @@ Then pin the app: `mlxVideoMinVersion` in `LTXVideoGenerator/Sources/PythonEnvir
 
 ## App release (this repo)
 
-Unreleased user-facing work on `main` needs a version tag. Last pattern: `2.3.67`.
+Unreleased user-facing work on `main` needs a version tag. Current marketing version lives in `project.pbxproj` (`MARKETING_VERSION`; last shipped pattern `2.3.x`).
 
 1. Move `CHANGELOG.md` `## Unreleased` into `## [X.Y.Z] - YYYY-MM-DD` (today is 2026+)
 2. Bump both `MARKETING_VERSION` entries in `LTXVideoGenerator/LTXVideoGenerator.xcodeproj/project.pbxproj`
@@ -54,11 +192,11 @@ Default: review, thank the author by name, then merge or close with a concrete r
 - Hugging Face cache: `HuggingFaceCacheConfiguration` (`HF_HOME` + `HF_HUB_CACHE`). Apply it on every Process env that can download weights (generation, Gemma preview, MLX Audio). Fail closed if the configured folder is missing/unwritable
 - REST API (`APIServer.swift`) binds `127.0.0.1` because `/generate` accepts local file paths. Do not bind `0.0.0.0` again
 - Generation log: `/tmp/ltx_generation.log`. User-facing alerts stay short
-- Cancel must kill the Python process group, not just the Swift `Task`
+- Cancel must kill the Python process group (or H3 process), not just the Swift `Task`
 
 ## Changelog and docs
 
-Keep a Changelog + semver. User-facing behavior goes in `CHANGELOG.md` under Unreleased until the version tag. Mention Settings paths and min package versions when they change. README / `docs/installation.md` for storage and API examples.
+Keep a Changelog + semver. User-facing behavior goes in `CHANGELOG.md` under Unreleased until the version tag. Mention Settings paths and min package versions when they change. README / `docs/installation.md` for storage and API examples. Architecture: `docs/architecture.md`.
 
 ## Commit style
 
@@ -92,4 +230,6 @@ Do not commit unless the user asks, except when they already asked to cut a rele
 ```bash
 cat /tmp/ltx_generation.log
 pip show mlx-video-with-audio
+pip show ltx-pipelines-mlx ltx-core-mlx 2>/dev/null || true
+which ltx-2-mlx; ltx-2-mlx --help 2>/dev/null | head
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.3.83] - 2026-09-07
+
 ### Added
 - LTX-2.5 / ltx-2-mlx now forwards additional timeline keyframes as repeatable `--image PATH FRAME_IDX STRENGTH` (pixel frame indices).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- LTX-2.5 / ltx-2-mlx now forwards additional timeline keyframes as repeatable `--image PATH FRAME_IDX STRENGTH` (pixel frame indices).
+
+### Fixed
+- LTX-2.5 DurationHead loads on `mlx-community/ltx-2.5-mlx` (pre-split q/k/v). Enables `--auto-duration` when `-f` is omitted; app still passes explicit frames from the slider.
+
 ## [2.3.82] - 2026-09-07
 
 ### Fixed

--- a/LTXVideoGenerator/LTXVideoGenerator.xcodeproj/project.pbxproj
+++ b/LTXVideoGenerator/LTXVideoGenerator.xcodeproj/project.pbxproj
@@ -416,7 +416,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.3.82;
+				MARKETING_VERSION = 2.3.83;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ltxvideo.generator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -444,7 +444,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.3.82;
+				MARKETING_VERSION = 2.3.83;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jamescampbell.ltxvideogenerator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LTXVideoGenerator/Resources/ltx25_community_adapter.py
+++ b/LTXVideoGenerator/Resources/ltx25_community_adapter.py
@@ -8,8 +8,8 @@ mlx-lm layout under gemma4-12b-ltx-v1/.
 baa-ai/LTX-2.3-22B-RAM-12GB-MLX is mixed-precision (2–8 bit). Stock
 apply_quantization uses one bit width; we apply per-layer nn.quantize.
 
-Also skips DurationHead when the pack has split q/k/v keys (0.15.2 expects
-fused in_proj). We always pass --frames.
+Patches DurationHead load for community packs that already ship split q/k/v
+(0.15.2 ``load_duration_head`` only expects fused torch ``in_proj``).
 """
 
 from __future__ import annotations
@@ -158,6 +158,83 @@ def apply_patches() -> None:
 
     weights_mod.load_split_safetensors = load_split_safetensors
     blocks.load_split_safetensors = load_split_safetensors
+
+    # mlx-community/ltx-2.5-mlx already stores split q/k/v; 0.15.2 pops fused
+    # in_proj_* and KeyErrors. Accept either layout.
+    from ltx_core_mlx.duration_head import duration_head as duration_head_mod
+
+    _orig_load_duration = duration_head_mod.load_duration_head
+
+    def load_duration_head(path):
+        path = Path(path)
+        if not path.exists():
+            raise FileNotFoundError("duration head weights not found at %s" % path)
+
+        import mlx.core as mx
+        from ltx_core_mlx.duration_head.duration_head import DurationHead
+        from ltx_core_mlx.utils.weights import load_split_safetensors
+
+        prefix = duration_head_mod._PACK_PREFIX
+        raw = load_split_safetensors(path, prefix=prefix)
+
+        hidden_dim = raw["video_modality_emb"].shape[0]
+        video_dim = raw["video_input_proj.weight"].shape[1]
+        audio_dim = raw["audio_input_proj.weight"].shape[1]
+        mlp_hidden_dim = raw["mlp_hidden.weight"].shape[0]
+        num_queries = raw["attention_pooler.query_tokens"].shape[0]
+        num_heads = 4
+
+        fused_w = "attention_pooler.cross_attn.in_proj_weight"
+        fused_b = "attention_pooler.cross_attn.in_proj_bias"
+        if fused_w in raw and fused_b in raw:
+            in_proj_weight = raw.pop(fused_w)
+            in_proj_bias = raw.pop(fused_b)
+            q_w, k_w, v_w = mx.split(in_proj_weight, 3, axis=0)
+            q_b, k_b, v_b = mx.split(in_proj_bias, 3, axis=0)
+            raw["attention_pooler.cross_attn.q_proj.weight"] = q_w
+            raw["attention_pooler.cross_attn.q_proj.bias"] = q_b
+            raw["attention_pooler.cross_attn.k_proj.weight"] = k_w
+            raw["attention_pooler.cross_attn.k_proj.bias"] = k_b
+            raw["attention_pooler.cross_attn.v_proj.weight"] = v_w
+            raw["attention_pooler.cross_attn.v_proj.bias"] = v_b
+            print(
+                "DurationHead: fused in_proj -> q/k/v (%s)" % path.name,
+                file=sys.stderr,
+                flush=True,
+            )
+        elif all(
+            k in raw
+            for k in (
+                "attention_pooler.cross_attn.q_proj.weight",
+                "attention_pooler.cross_attn.k_proj.weight",
+                "attention_pooler.cross_attn.v_proj.weight",
+            )
+        ):
+            print(
+                "DurationHead: using pre-split q/k/v (%s)" % path.name,
+                file=sys.stderr,
+                flush=True,
+            )
+        else:
+            return _orig_load_duration(path)
+
+        model = DurationHead(
+            video_cross_attention_dim=video_dim,
+            audio_cross_attention_dim=audio_dim,
+            pooler_hidden_dim=hidden_dim,
+            num_queries=num_queries,
+            num_pooler_heads=num_heads,
+            mlp_hidden_dim=mlp_hidden_dim,
+        )
+        model.load_weights(list(raw.items()))
+        return model
+
+    duration_head_mod.load_duration_head = load_duration_head
+    import ltx_core_mlx.duration_head as duration_head_pkg
+
+    duration_head_pkg.load_duration_head = load_duration_head
+    # blocks imported load_duration_head by name; rebind so from_checkpoint sees it.
+    blocks.load_duration_head = load_duration_head
 
     _orig_duration = DurationPredictor.from_checkpoint
 

--- a/LTXVideoGenerator/Sources/Models/GenerationRequest.swift
+++ b/LTXVideoGenerator/Sources/Models/GenerationRequest.swift
@@ -518,8 +518,8 @@ enum GenerationStatus: String, Codable, Equatable {
 }
 
 /// A single conditioning image pinned to a position along the video timeline.
-/// `position` is a fraction 0.0...1.0 (0 = first frame, 1 = last frame); the
-/// generation bridge maps it to a latent frame index based on `numFrames`.
+/// `position` is a fraction 0.0...1.0 (0 = first frame, 1 = last frame).
+/// `mlxVideoWithAudio` maps to a latent frame index; `ltx2Mlx` maps to a pixel frame index.
 struct Keyframe: Codable, Equatable, Hashable, Identifiable {
     var id: UUID = UUID()
     var imagePath: String

--- a/LTXVideoGenerator/Sources/Services/LTXBridge.swift
+++ b/LTXVideoGenerator/Sources/Services/LTXBridge.swift
@@ -947,13 +947,31 @@ except Exception as e:
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
             .replacingOccurrences(of: "\n", with: "\\n")
-        let imagePath = request.sourceImagePath ?? ""
-        let extraKeyframes = params.keyframes.contains { !$0.imagePath.isEmpty }
+        // ltx-2-mlx --image uses pixel frame indices (not latent like mlx-video --keyframe).
+        let lastPixelIdx = max(0, params.numFrames - 1)
+        func pixelIndex(forFraction f: Double) -> Int {
+            let idx = Int((f * Double(lastPixelIdx)).rounded())
+            return min(max(idx, 0), lastPixelIdx)
+        }
+        func pyEscape(_ s: String) -> String {
+            s.replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "\"", with: "\\\"")
+        }
+        var imageSpecs: [String] = []
+        if let primary = request.sourceImagePath, !primary.isEmpty {
+            let idx = request.parameters.imageFramePosition == "last" ? lastPixelIdx : 0
+            imageSpecs.append("\(pyEscape(primary))|\(idx)|\(params.imageStrength)")
+        }
+        for kf in params.keyframes where !kf.imagePath.isEmpty {
+            let idx = pixelIndex(forFraction: kf.position)
+            imageSpecs.append("\(pyEscape(kf.imagePath))|\(idx)|\(kf.strength)")
+        }
+        let imagesPyList = "[" + imageSpecs.map { "\"\($0)\"" }.joined(separator: ", ") + "]"
         let adapterPath = Bundle.main.bundlePath + "/Contents/Resources/ltx25_community_adapter.py"
 
         progressHandler(0.1, "Starting \(request.isImageToVideo ? "image-to-video" : "text-to-video") (\(selectedModel.displayName))...")
-        if extraKeyframes {
-            progressHandler(0.11, "Extra timeline keyframes are not forwarded on the ltx-2-mlx backend yet; using the primary image only.")
+        if imageSpecs.count > 1 {
+            progressHandler(0.11, "Conditioning \(imageSpecs.count) images (ltx-2-mlx --image, pixel frames)...")
         }
 
         let tilingArgs: String
@@ -989,7 +1007,7 @@ try:
     model_repo = "\(modelRepo)"
     dit_repo = "\(ditRepo)"
     gemma_repo = "\(gemmaRepo)"
-    image_path = "\(imagePath)"
+    image_specs = \(imagesPyList)
     local_repo = os.path.expanduser("~/projects/ltx-2-mlx")
     use_local = \(useLocalLtx2 ? "True" : "False") and os.path.isdir(local_repo)
 
@@ -1137,11 +1155,13 @@ try:
     if gemma_repo:
         cmd.extend(["--gemma", gemma_repo])
         log(f"Gemma text encoder: {gemma_repo}")
-    if image_path:
-        cmd.extend(["--image", image_path])
-        log(f"I2V image: {image_path}")
+    # Repeatable --image PATH FRAME_IDX STRENGTH (pixel frame index).
+    for spec in image_specs:
+        path, idx_s, strength_s = spec.split("|", 2)
+        cmd.extend(["--image", path, idx_s, strength_s])
+        log(f"I2V image: {path} @ pixel {idx_s} strength={strength_s}")
     if \(request.disableAudio ? "True" : "False"):
-        log("Generate Audio off is ignored on ltx-2-mlx 0.15.2 (no --no-audio flag)")
+        log("Generate Audio off is ignored on ltx-2-mlx 0.15.2 (no --no-audio; see dgrauet/ltx-2-mlx#126)")
     if \(enableEnhance ? "True" : "False"):
         cmd.append("--enhance-prompt")
     if \(useLowRam ? "True" : "False"):

--- a/LTXVideoGenerator/Sources/Views/PromptInputView.swift
+++ b/LTXVideoGenerator/Sources/Views/PromptInputView.swift
@@ -428,7 +428,7 @@ struct PromptInputView: View {
                             )
                         }
 
-                        Text("Position: 0% = first frame, 100% = last frame. There are only ~\(max(1, 1 + (parameters.numFrames - 1) / 8)) distinct latent slots, so nearby positions may land on the same frame.")
+                        Text("Position: 0% = first frame, 100% = last frame. LTX-2/2.3 map to ~\(max(1, 1 + (parameters.numFrames - 1) / 8)) latent slots; LTX-2.5 uses pixel frame indices on ltx-2-mlx.")
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                     }


### PR DESCRIPTION
## Summary
- Forward extra timeline keyframes on `ltx2Mlx` via repeatable `--image PATH FRAME_IDX STRENGTH` (pixel frames)
- Fix DurationHead load for `mlx-community/ltx-2.5-mlx` pre-split q/k/v in `ltx25_community_adapter.py`
- Refresh `AGENTS.md` (backends, 2.5 parity, build/deps); ship as **2.3.83**
- Tracks https://github.com/james-see/ltx-video-mac/issues/85 (upstream #125/#126/#127)

## Test plan
- [x] Debug build succeeds
- [ ] LTX-2.5 Distilled I2V with primary + one extra keyframe at 100%
- [ ] Check `/tmp/ltx_generation.log` for multiple `--image` lines and `DurationHead: using pre-split q/k/v` when adapter loads